### PR TITLE
Update json_value_body.typ

### DIFF
--- a/json_value_body.typ
+++ b/json_value_body.typ
@@ -31,7 +31,10 @@ type body json_value as
     if(dbms_lob.getlength(str) > 32767) then
       extended_str := str;
     end if;
-    dbms_lob.read(str, amount, 1, self.str);
+    -- GHS 20120615: Added IF structure to handle null clobs
+    if dbms_lob.getlength(str) > 0 then
+      dbms_lob.read(str, amount, 1, self.str);
+    end if;
     return;
   end json_value;
 


### PR DESCRIPTION
Solves null clob issue originally first seen when invoking json_dyn.executelist() on a table with null clobs.  Attempting to execute dbms_lob.read() on a null clob raises the following error:

ERROR: ORA-06502: PL/SQL: numeric or value error: invalid LOB locator specified: ORA-22275
