### PR TITLE
fix testall.sql to run correctly through all individual test files

### DIFF
--- a/testsuite/ext_test.sql
+++ b/testsuite/ext_test.sql
@@ -145,3 +145,4 @@ begin
     when others then null;
   end;
 end;
+/

--- a/testsuite/json_list_test.sql
+++ b/testsuite/json_list_test.sql
@@ -356,3 +356,4 @@ begin
     when others then null;
   end;
 end;
+/

--- a/testsuite/json_test.sql
+++ b/testsuite/json_test.sql
@@ -291,3 +291,4 @@ begin
     when others then null;
   end;
 end;
+/

--- a/testsuite/jsonpath.sql
+++ b/testsuite/jsonpath.sql
@@ -310,3 +310,4 @@ begin
     when others then null;
   end;
 end;
+/

--- a/testsuite/simple_test.sql
+++ b/testsuite/simple_test.sql
@@ -71,3 +71,4 @@ begin
     when others then null;
   end;
 end;
+/

--- a/testsuite/testall.sql
+++ b/testsuite/testall.sql
@@ -26,7 +26,7 @@ CREATE TABLE "JSON_TESTSUITE" (
   "TOTAL" NUMBER, 
   "FILENAME" VARCHAR2(20 BYTE)
 );  
-/
+
 --run each test here
 @jsonparsertest.sql
 @json_test.sql
@@ -39,4 +39,4 @@ PROMPT Unit-testing of PLJSON implementation:
 select * from json_testsuite;
 --select 'All tests', sum(passed), sum(failed), sum(total), ' ' from json_testsuite;
 drop table json_testsuite;
-/
+


### PR DESCRIPTION
When I run the `testall.sql` it does not run all the tests and emits a couple of what appear to be syntax errors. Here is the current output:

```
$ sqlplus pljson@vmdb12 @testall.sql

SQL*Plus: Release 11.2.0.3.0 Production on Thu Apr 2 23:36:54 2015

Copyright (c) 1982, 2012, Oracle.  All rights reserved.

Enter password:

Connected to:
Oracle Database 12c Enterprise Edition Release 12.1.0.1.0 - 64bit Production
With the Partitioning, OLAP, Advanced Analytics and Real Application Testing options


Table created.

CREATE TABLE "JSON_TESTSUITE" (
             *
ERROR at line 1:
ORA-00955: name is already used by an existing object


Scanner testing:
OK: number test A
OK: digits test A
OK: digits test B
OK: digits test C
OK: digits exp test A
OK: digits exp test B
OK: digits exp test C
OK: digits exp test D
OK: string test A
OK: unicode character test A
OK: unicode character test A
OK: unicode character test B
OK: escape character test A
OK: escape character test B
OK: boolean test A
OK: boolean test B
OK: boolean test C
OK: boolean test D
OK: boolean test E
OK: null test A
OK: null test B
OK: unexpected char l.226
OK: Unicode char test - on UTF8 databases
OK: Lexer String ending test

Parser testing:
OK: array expecting value got }
OK: premature exit from array
OK: premature exit from array2
OK: premature exit from array3
OK: premature exit from array4
OK: commas between values in array 1
OK: commas between values in array 2
OK: remember to end array
OK: empty array
OK: empty array in array
OK: wild array
OK: wrong member start test
OK: normal members test
OK: same membername in same scope test
OK: Object suddently ends
OK: missing :
OK: missing value
OK: another pair expected
OK: } not found
OK: empty object A
OK: empty object B
OK: { missing
OK: } missing
OK: , missing
OK: Duplicate 1
OK: Duplicate 2

Passed 49 of 49 tests.
Failed 0 of 49 tests.

PL/SQL procedure successfully completed.

SP2-0552: Bind variable "SELECT" not declared.
SQL>
```

With these minor syntax changes, the `testall.sql` seems to be working as expected now. Here is sample output from running the script after the changes are made:

```
$ sqlplus pljson@vmdb12 @testall.sql

SQL*Plus: Release 11.2.0.3.0 Production on Thu Apr 2 23:33:37 2015

Copyright (c) 1982, 2012, Oracle.  All rights reserved.

Enter password:

Connected to:
Oracle Database 12c Enterprise Edition Release 12.1.0.1.0 - 64bit Production
                                                                                                                                                       [207/298]

Table created.

Scanner testing:
OK: number test A
OK: digits test A
OK: digits test B
OK: digits test C
OK: digits exp test A
OK: digits exp test B
OK: digits exp test C
OK: digits exp test D
OK: string test A
OK: unicode character test A
OK: unicode character test A
OK: unicode character test B
OK: escape character test A
OK: escape character test B
OK: boolean test A
OK: boolean test B
OK: boolean test C
OK: boolean test D
OK: boolean test E
OK: null test A
OK: null test B
OK: unexpected char l.226
OK: Unicode char test - on UTF8 databases
OK: Lexer String ending test

Parser testing:
OK: array expecting value got }
OK: premature exit from array
OK: premature exit from array2
OK: premature exit from array3
OK: premature exit from array4
OK: commas between values in array 1
OK: commas between values in array 2
OK: remember to end array
OK: empty array
OK: empty array in array
OK: wild array
OK: wrong member start test
OK: normal members test
OK: same membername in same scope test
OK: Object suddently ends
OK: missing :
OK: missing value
OK: another pair expected
OK: } not found
OK: empty object A
OK: empty object B
OK: { missing
OK: } missing
OK: , missing
OK: Duplicate 1
OK: Duplicate 2

Passed 49 of 49 tests.
Failed 0 of 49 tests.

PL/SQL procedure successfully completed.

OK: Empty JSON test
OK: Put method JSON test
OK: Put method JSON test with position
OK: Put method type test
OK: Remove method test
OK: Get method test
OK: Number null insert test
OK: Varchar2 null insert test
OK: Bool null insert test
OK: Null null insert test
OK: json null insert test
OK: json_list null insert test
OK: json null pair_name insert test

PL/SQL procedure successfully completed.

OK: Empty list test
OK: Empty list test and remove
OK: Empty list test and add element
OK: List parser constructor link test
OK: List parser constructor link test 2
OK: Add different types test
OK: Add with position
OK: Remove with position
OK: Remove First                                                                                                                                       [120/298]
OK: Remove Last
OK: Get elem with position
OK: Get first and last
OK: Number null insert test
OK: Varchar2 null insert test
OK: Bool null insert test
OK: Null null insert test
OK: json_list null insert test
OK: json_list replace test

PL/SQL procedure successfully completed.

OK: Bool test
OK: Null test

PL/SQL procedure successfully completed.

OK: Is Type Test
OK: Is Type Test 2 (integers)
OK: Date interaction test 1
OK: Date interaction test 2
OK: Null date insert into json

PL/SQL procedure successfully completed.

OK: Getters simple
OK: Getters with arrays
OK: Getters with mixed structures
OK: Getters with spaces
OK: Getter: all types
OK: Putter simple
OK: Putter array
OK: Putter advanced
OK: Putter: all types
OK: Putter build
OK: Putter exceptions
OK: Remove simple
OK: Remove advanced
OK: Getter index with [" "]
OK: Putter index with [" "]

PL/SQL procedure successfully completed.

Unit-testing of PLJSON implementation:

COLLECTION               PASSED     FAILED      TOTAL FILENAME
-------------------- ---------- ---------- ---------- --------------------
Parser testing               49          0         49 jsonparsertest.sql
JSON testing                 13          0         13 json_test.sql
List testing                 18          0         18 json_list_test.sql
Simple type test              2          0          2 simple_test.sql
JSON_Ext testing              5          0          5 ext_test.sql
JSON_Path testing            15          0         15 jsonpath.sql

6 rows selected.


Table dropped.

SQL>
```

Thanks..