### PR TITLE
made JSON_PRINTER.escapeString 4 times faster

### DIFF
--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -73,28 +73,31 @@ package body "JSON_PRINTER" as
   
   -- escapes a single character. 
   function escapeChar(ch char) return varchar2 deterministic is
+     result varchar2(20);
   begin
       --backspace b = U+0008
       --formfeed  f = U+000C
       --newline   n = U+000A
       --carret    r = U+000D
       --tabulator t = U+0009
+      result := ch;
+      
       case ch
-      when chr( 8) then return '\b';
-      when chr( 9) then return '\t';
-      when chr(10) then return '\n';
-      when chr(12) then return '\f';
-      when chr(13) then return '\r';
-      when chr(34) then return  '\"';
-      when chr(47) then if(escape_solidus) then return '\/'; end if;
-      when chr(92) then return '\\';
+      when chr( 8) then result := '\b';
+      when chr( 9) then result := '\t';
+      when chr(10) then result := '\n';
+      when chr(12) then result := '\f';
+      when chr(13) then result := '\r';
+      when chr(34) then result := '\"';
+      when chr(47) then if(escape_solidus) then result := '\/'; end if;
+      when chr(92) then result := '\\';
       else if(ascii(ch) < 32) then
-             return '\u'||replace(substr(to_char(ascii(ch), 'XXXX'),2,4), ' ', '0');
+             result :=  '\u'||replace(substr(to_char(ascii(ch), 'XXXX'),2,4), ' ', '0');
         elsif (ascii_output) then 
-             return replace(asciistr(ch), '\', '\u');
+             result := replace(asciistr(ch), '\', '\u');
         end if;
       end case;    
-      return ch;  
+      return result;  
   end;
 
 


### PR DESCRIPTION
Added a cache (implemented by an associative array) to avoid re-executing the conversion of the same character over and over. 

the core idea is what happens to the buf variable in this loop (char_map is the associative array):

     for i in 1 .. length(str) loop
          ch := substr(str, i, 1 ) ;
          begin                    
             -- if this char has already been processed, 
             -- the cache contains its its escaped value 
             -- (or it contains the character itself if it doesn't need any conversion)
             buf := char_map(ch);  
          exception when no_Data_found then
             -- otherwise, i convert the value and add it to the cache
             buf := escapeChar(ch);
             char_map(ch) := buf;
          end; 
          ....  

the cache is kept across multiple calls and gets cleared only if someone changes the "escape_solidus" or "ascii_output" global variables.
I have moved, for readability, the conversion logic of a single char into the escapechar() function.

