### PR TITLE
Unicode strings in json without ORA-6502 errors

### DIFF
--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -285,12 +285,12 @@ package body "JSON_PRINTER" as
               end loop;
             end;
           else
-            if(elem.num = 1) then
-              add_to_clob(buf, buf_str, llcheck('"'||escapeString(elem.get_string)||'"'));
-              --add_escaped_string_to_clob(buf, buf_str, elem.get_string);
-            else
-              add_to_clob(buf, buf_str, llcheck('/**/'||elem.get_string||'/**/'));
-            end if;
+            --if(elem.num = 1) then
+              --add_to_clob(buf, buf_str, llcheck('"'||escapeString(elem.get_string)||'"'));
+              add_escaped_string_to_clob(buf, buf_str, elem.get_string);
+            --else
+            --  add_to_clob(buf, buf_str, llcheck('/**/'||elem.get_string||'/**/'));
+            --end if;
           end if;
           add_to_clob(buf, buf_str, case when elem.num = 1 then '"' else '/**/' end || newline_char);
         when 'bool' then

--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -48,7 +48,7 @@ package body "JSON_PRINTER" as
   -- escaped so far  (example: char_map('"') contains the  '\"' string)
   -- (if the character does not need to be escaped, the character is stored unchanged in the array itself)
   type Rmap_char is record(buf varchar2(40), len integer);
-  type Tmap_char_string is table of Rmap_char index by varchar2(1 CHAR); /* index by 1 CHAR */
+  type Tmap_char_string is table of Rmap_char index by varchar2(1 CHAR); /* index by unicode CHAR */
        char_map Tmap_char_string;                    
        -- since char_map the associative array is a global variable reused across multiple calls to escapeString,
        -- i need to be able to detect that the escape_solidus or ascii_output global parameters have been changed,

--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -178,8 +178,7 @@ package body "JSON_PRINTER" as
 /* Clob method start here */
   procedure add_to_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2, str varchar2) as
   begin
-    --if(lengthb(str) > 32767 - lengthb(buf_str)) then
-    if(length(str) > 5000 - length(buf_str)) then /* restrict to max escaped unicode string size */
+    if(lengthb(str) > 32767 - lengthb(buf_str)) then
 --      dbms_lob.append(buf_lob, buf_str);
       dbms_lob.writeappend(buf_lob, length(buf_str), buf_str);
       buf_str := str;

--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -48,7 +48,7 @@ package body "JSON_PRINTER" as
   -- escaped so far  (example: char_map('"') contains the  '\"' string)
   -- (if the character does not need to be escaped, the character is stored unchanged in the array itself)
   type Rmap_char is record(buf varchar2(40), len integer);
-  type Tmap_char_string is table of Rmap_char index by varchar2(1 CHAR); /* index by unicode CHAR */
+  type Tmap_char_string is table of Rmap_char index by varchar2(1 char); /* index by unicode char */
        char_map Tmap_char_string;                    
        -- since char_map the associative array is a global variable reused across multiple calls to escapeString,
        -- i need to be able to detect that the escape_solidus or ascii_output global parameters have been changed,
@@ -105,7 +105,7 @@ package body "JSON_PRINTER" as
     sb_length number:=0;
     buf varchar2(40);
     buf_length number;
-    ch varchar2(1 CHAR); /* unicode CHAR */
+    ch varchar2(1 char); /* unicode char */
   begin
     if(str is null) then return ''; end if;
 
@@ -199,7 +199,7 @@ package body "JSON_PRINTER" as
     new_sb_length number;
     buf varchar2(40);
     buf_length integer;
-    ch varchar2(1 CHAR); /* unicode CHAR */
+    ch varchar2(1 char); /* unicode char */
   begin
     if(str is null) then return; end if;
     -- clear the cache if global parameters have been changed

--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -1,17 +1,14 @@
 create or replace package json_printer as
   /*
   Copyright (c) 2010 Jonas Krogsboell
-
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -51,7 +48,7 @@ package body "JSON_PRINTER" as
   -- escaped so far  (example: char_map('"') contains the  '\"' string)
   -- (if the character does not need to be escaped, the character is stored unchanged in the array itself)
   type Rmap_char is record(buf varchar2(40), len integer);
-  type Tmap_char_string is table of Rmap_char index by varchar2(1);                         
+  type Tmap_char_string is table of Rmap_char index by varchar2(4); /* index by max unicode size in bytes */
        char_map Tmap_char_string;                    
        -- since char_map the associative array is a global variable reused across multiple calls to escapeString,
        -- i need to be able to detect that the escape_solidus or ascii_output global parameters have been changed,
@@ -108,7 +105,7 @@ package body "JSON_PRINTER" as
     sb_length number:=0;
     buf varchar2(40);
     buf_length number;
-    ch varchar2(1 char);
+    ch varchar(4); /* 4 bytes max unicode char */
   begin
     if(str is null) then return ''; end if;
 
@@ -181,7 +178,8 @@ package body "JSON_PRINTER" as
 /* Clob method start here */
   procedure add_to_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2, str varchar2) as
   begin
-    if(lengthb(str) > 32767 - lengthb(buf_str)) then
+    --if(lengthb(str) > 5000 - lengthb(buf_str)) then
+    if(length(str) > 5000 - length(buf_str)) then
 --      dbms_lob.append(buf_lob, buf_str);
       dbms_lob.writeappend(buf_lob, length(buf_str), buf_str);
       buf_str := str;
@@ -202,7 +200,7 @@ package body "JSON_PRINTER" as
     new_sb_length number;
     buf varchar2(40);
     buf_length integer;
-    ch varchar2(1 char);
+    ch varchar(4); /* 4 bytes max unicode size; must be varchar2 */
   begin
     if(str is null) then return; end if;
     -- clear the cache if global parameters have been changed
@@ -245,6 +243,7 @@ package body "JSON_PRINTER" as
     -- add rest ob result to clob
     add_to_clob(buf_lob, buf_str, sb);
   end;
+  
   procedure ppObj(obj json, indent number, buf in out nocopy clob, spaces boolean, buf_str in out nocopy varchar2);
 
   procedure ppEA(input json_list, indent number, buf in out nocopy clob, spaces boolean, buf_str in out nocopy varchar2) as
@@ -272,13 +271,13 @@ package body "JSON_PRINTER" as
             declare
               offset number := 1;
               v_str varchar(32767);
-              amount number := 32767;
+              amount number := 5000;
             begin
               while(offset <= dbms_lob.getlength(elem.extended_str)) loop
                 dbms_lob.read(elem.extended_str, amount, offset, v_str);
                 if(elem.num = 1) then
-                  --add_to_clob(buf, buf_str, escapeString(v_str));
-                  add_escaped_string_to_clob(buf, buf_str, v_str);
+                  add_to_clob(buf, buf_str, escapeString(v_str));
+                  -- add_escaped_string_to_clob(buf, buf_str, v_str);
                 else
                   add_to_clob(buf, buf_str, v_str);
                 end if;
@@ -336,7 +335,7 @@ package body "JSON_PRINTER" as
           declare
             offset number := 1;
             v_str varchar(32767);
-            amount number := 32767;
+            amount number := 5000;
           begin
 --            dbms_output.put_line('SIZE:'||dbms_lob.getlength(mem.extended_str));
             while(offset <= dbms_lob.getlength(mem.extended_str)) loop
@@ -345,8 +344,8 @@ package body "JSON_PRINTER" as
               dbms_lob.read(mem.extended_str, amount, offset, v_str);
 --            dbms_output.put_line('VSTR_SIZE:'||length(v_str));
               if(mem.num = 1) then
-                --add_to_clob(buf, buf_str, escapeString(v_str));
-                add_escaped_string_to_clob(buf, buf_str, v_str);
+                add_to_clob(buf, buf_str, escapeString(v_str));
+                --add_escaped_string_to_clob(buf, buf_str, v_str);
               else
                 add_to_clob(buf, buf_str, v_str);
               end if;
@@ -444,13 +443,13 @@ package body "JSON_PRINTER" as
           declare
             offset number := 1;
             v_str varchar(32767);
-            amount number := 32767;
+            amount number := 5000;
           begin
             while(offset <= dbms_lob.getlength(json_part.extended_str)) loop
               dbms_lob.read(json_part.extended_str, amount, offset, v_str);
               if(json_part.num = 1) then
-                --add_to_clob(buf, buf_str, escapeString(v_str));
-                add_escaped_string_to_clob(buf, buf_str, v_str);
+                add_to_clob(buf, buf_str, escapeString(v_str));
+                --add_escaped_string_to_clob(buf, buf_str, v_str);
               else
                 add_to_clob(buf, buf_str, v_str);
               end if;
@@ -640,7 +639,7 @@ package body "JSON_PRINTER" as
     indx number := 1;
     size_of_nl number := lengthb(delim);
     v_str varchar2(32767);
-    amount number := 32767;
+    amount number := 5000;
   begin
     if(jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
     while(indx != 0) loop
@@ -650,7 +649,7 @@ package body "JSON_PRINTER" as
       
       if(indx = 0) then
         --emit from prev to end;
-        amount := 32767;
+        amount := 5000;
  --       dbms_output.put_line(' mycloblen ' || dbms_lob.getlength(my_clob));
         loop
           dbms_lob.read(my_clob, amount, prev, v_str);
@@ -660,8 +659,8 @@ package body "JSON_PRINTER" as
         end loop;
       else 
         amount := indx - prev;
-        if(amount > 32767) then 
-          amount := 32767;
+        if(amount > 5000) then 
+          amount := 5000;
 --          dbms_output.put_line(' mycloblen ' || dbms_lob.getlength(my_clob));
           loop
             dbms_lob.read(my_clob, amount, prev, v_str);
@@ -669,7 +668,7 @@ package body "JSON_PRINTER" as
             prev := prev+amount-1;
             amount := indx - prev;
             exit when prev >= indx - 1;
-            if(amount > 32767) then amount := 32767; end if;
+            if(amount > 5000) then amount := 5000; end if;
           end loop;
           prev := indx + size_of_nl;
         else 
@@ -689,7 +688,6 @@ package body "JSON_PRINTER" as
       if(indx = 0) then 
         indx := dbms_lob.getlength(my_clob)+1;
       end if;
-
       if(indx-prev > 32767) then
         indx := prev+32767;
       end if;

--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -48,7 +48,7 @@ package body "JSON_PRINTER" as
   -- escaped so far  (example: char_map('"') contains the  '\"' string)
   -- (if the character does not need to be escaped, the character is stored unchanged in the array itself)
   type Rmap_char is record(buf varchar2(40), len integer);
-  type Tmap_char_string is table of Rmap_char index by varchar2(4); /* index by max unicode size in bytes */
+  type Tmap_char_string is table of Rmap_char index by varchar2(1 CHAR); /* index by 1 CHAR */
        char_map Tmap_char_string;                    
        -- since char_map the associative array is a global variable reused across multiple calls to escapeString,
        -- i need to be able to detect that the escape_solidus or ascii_output global parameters have been changed,
@@ -105,7 +105,7 @@ package body "JSON_PRINTER" as
     sb_length number:=0;
     buf varchar2(40);
     buf_length number;
-    ch varchar(4); /* 4 bytes max unicode char */
+    ch varchar2(1 CHAR); /* unicode CHAR */
   begin
     if(str is null) then return ''; end if;
 
@@ -200,7 +200,7 @@ package body "JSON_PRINTER" as
     new_sb_length number;
     buf varchar2(40);
     buf_length integer;
-    ch varchar(4); /* 4 bytes max unicode size; must be varchar2 */
+    ch varchar2(1 CHAR); /* unicode CHAR */
   begin
     if(str is null) then return; end if;
     -- clear the cache if global parameters have been changed

--- a/src/json_value_body.typ
+++ b/src/json_value_body.typ
@@ -24,11 +24,11 @@ type body json_value as
   end json_value;
 
   constructor function json_value(str clob, esc boolean default true) return self as result as
-    amount number := 32767;
+    amount number := 5000; /* for Unicode text, all text/loops max 5000 CHAR) */
   begin
     self.typeval := 3;
     if(esc) then self.num := 1; else self.num := 0; end if; --message to pretty printer
-    if(dbms_lob.getlength(str) > 32767) then
+    if(dbms_lob.getlength(str) > amount) then
       extended_str := str;
     end if;
     -- GHS 20120615: Added IF structure to handle null clobs

--- a/src/json_value_body.typ
+++ b/src/json_value_body.typ
@@ -24,7 +24,7 @@ type body json_value as
   end json_value;
 
   constructor function json_value(str clob, esc boolean default true) return self as result as
-    amount number := 5000; /* for Unicode text, all text/loops max 5000 CHAR) */
+    amount number := 5000; /* for Unicode text, varchar2 'self.str' not exceed 5000 chars, does not limit size of data */
   begin
     self.typeval := 3;
     if(esc) then self.num := 1; else self.num := 0; end if; --message to pretty printer

--- a/testsuite/json_unicode_test.sql
+++ b/testsuite/json_unicode_test.sql
@@ -1,0 +1,158 @@
+/*
+  set of 5 tests exercising correct Unicode support and big strings for both clob and varchar2 api versions
+  test should not produce ORA-06502 error
+*/
+declare
+  test_json json;
+  test_json_list json_list;
+  clob_buf_1 clob;
+  clob_buf_2 clob;
+  var_buf_1 VARCHAR2(32767);
+  var_buf_2 VARCHAR2(32767);
+  json_clob clob;
+  json_var VARCHAR2(32767);
+  /* 64 chars */
+  text_2_byte VARCHAR2(200) := 'αβγδεζηθικλμνξοπρστυφχψωΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩάέήίόύώϊϋΆΈΉΊΌΎΏ';
+  /* 62 chars */
+  text_1_byte VARCHAR2(200) := '1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  CLOB_MAX_SIZE NUMBER := 256 * 1024;
+  VARCHAR2_1_BYTE_MAX_SIZE NUMBER := 32000; /* allow some space for json markup */
+  VARCHAR2_2_BYTE_MAX_SIZE NUMBER := 10000; /* allow some space for json markup */
+  i NUMBER;
+  k NUMBER;
+  t_start timestamp;
+  t_stop  timestamp;
+  t_sec NUMBER;
+begin
+
+  t_start := SYSTIMESTAMP;
+  
+  /* json with
+  1 clob string of ~ 256K 1-byte chars
+  1 clob string of ~ 256K 2-byte chars
+  1 varchar2 string of 32767 1-byte chars
+  1 varchar2 string of 5000  2-byte chars
+  */
+  dbms_lob.createtemporary(clob_buf_1, TRUE, dbms_lob.SESSION);
+  dbms_lob.trim(clob_buf_1, 0);
+  k := length(text_1_byte);
+  i := 0;
+  while i + k < CLOB_MAX_SIZE loop
+    dbms_lob.writeappend(clob_buf_1, k, text_1_byte);
+    i := i + k;
+  end loop;
+  dbms_output.put_line('clob_1 1-byte buffer, chars = ' || to_char(dbms_lob.getlength(clob_buf_1)));
+  
+  dbms_lob.createtemporary(clob_buf_2, TRUE, dbms_lob.SESSION);
+  dbms_lob.trim(clob_buf_2, 0);
+  k := length(text_2_byte);
+  i := 0;
+  while i + k < CLOB_MAX_SIZE loop
+    dbms_lob.writeappend(clob_buf_2, k, text_2_byte);
+    i := i + k;
+  end loop;
+  dbms_output.put_line('clob_2 2-byte buffer, chars = ' || to_char(dbms_lob.getlength(clob_buf_2)));
+  
+  i := 0;
+  k := lengthb(text_1_byte);
+  while i + k < VARCHAR2_1_BYTE_MAX_SIZE loop
+    var_buf_1 := var_buf_1 || text_1_byte;
+    i := i + k;
+  end loop;
+  dbms_output.put_line('var_1 1-byte buffer, bytes = ' || to_char(lengthb(var_buf_1)));
+  
+  i := 0;
+  k := lengthb(text_2_byte);
+  while i + k < VARCHAR2_2_BYTE_MAX_SIZE loop
+    var_buf_2 := var_buf_2 || text_2_byte;
+    i := i + k;
+  end loop;
+  dbms_output.put_line('var_2 2-byte buffer, bytes = ' || to_char(lengthb(var_buf_2)));
+  
+  test_json := json();
+  test_json.put('publish', true);
+  test_json.put('issueDate', to_char(sysdate, 'YYYY-MM-DD"T"HH24:MI:SS'));
+  test_json.put('clob_1', json_value(clob_buf_1));
+  test_json.put('clob_2', json_value(clob_buf_2));
+  test_json.put('var_1', var_buf_1);
+  test_json.put('var_2', var_buf_2);
+  
+  dbms_lob.createtemporary(json_clob, TRUE, dbms_lob.SESSION);
+  dbms_lob.trim(json_clob, 0);
+  
+  test_json.to_clob(json_clob);
+  dbms_output.put_line('test all kinds of big strings, clob final chars = ' || to_char(dbms_lob.getlength(json_clob)));
+    
+  dbms_lob.freetemporary(clob_buf_1);
+  dbms_lob.freetemporary(clob_buf_2);
+  dbms_lob.freetemporary(json_clob);
+  
+  /* json with
+  1 varchar2 string of 32767 1-byte chars
+  */
+  
+  test_json := json();
+  test_json.put('var_1', var_buf_1);
+
+  json_var := test_json.to_char();
+  
+  dbms_output.put_line('test 1 varchar2 string of 32000 1-byte chars, varchar2 final bytes = ' || to_char(lengthb(json_var)));
+  
+  /* json with
+  1 varchar2 string of 5000 2-byte chars
+  */
+  
+  test_json := json();
+  test_json.put('var_2', var_buf_2);
+
+  json_var := test_json.to_char();
+  
+  dbms_output.put_line('test 1 varchar2 string of 5000 2-byte chars, varchar2 final bytes = ' || to_char(lengthb(json_var)));
+  
+  /* json list with many small strings of 62 1-byte characters
+     but up to 32767 bytes total
+  */
+  test_json := json();
+  test_json_list := json_list();
+  for i in 1..496 loop
+    test_json_list.append(json_value(text_1_byte));
+  end loop;
+  test_json.put('array', test_json_list);
+  json_var := test_json.to_char();
+  
+  dbms_output.put_line('test list of 1-byte chars, varchar2 final bytes = ' || to_char(lengthb(json_var)));
+  
+  /* json list with many small strings of 64 2-byte characters
+     but up to 32767 bytes total
+  */
+  test_json := json();
+  test_json_list := json_list();
+  for i in 1..83 loop
+    test_json_list.append(json_value(text_2_byte));
+  end loop;
+  test_json.put('array', test_json_list);
+  json_var := test_json.to_char();
+  
+  dbms_output.put_line('test list of 2-byte chars, varchar2 final bytes = ' || to_char(lengthb(json_var)));
+  
+  t_stop := SYSTIMESTAMP;
+  t_sec := extract(second from t_stop - t_start);
+  dbms_output.put_line('total sec = ' || to_char(t_sec));
+  
+  /* 
+  expected output
+
+  clob_1 1-byte buffer, chars = 262136
+  clob_2 2-byte buffer, chars = 262080
+  var_1 1-byte buffer, bytes = 31992
+  var_2 2-byte buffer, bytes = 9984
+  test all kinds of big strings, clob final chars = 1896666
+  test 1 varchar2 string of 32000 1-byte chars, varchar2 final bytes = 32012
+  test 1 varchar2 string of 5000 2-byte chars, varchar2 final bytes = 29972
+  test list of 1-byte chars, varchar2 final bytes = 32754
+  test list of 2-byte chars, varchar2 final bytes = 32222
+  total sec = [4.8 - 5.2 sec on old Pentium 2.80 GHz development machine]
+
+  */
+end;
+/


### PR DESCRIPTION
Hello,

my test procedure (updated a bit for testing the new fork) is

```
create or replace procedure json_test as
test_clob_json json;
test_clob clob;
json_clob clob;
test_buf VARCHAR2(200) := 'αβγδεζηθικλμνξοπρστυφχψωΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩάέήίόύώϊϋΆΈΉΊΌΎΏ';
test_var VARCHAR2(3900 CHAR);
test_var_json json;
json_var varchar2(32767);
i number;
k number;
begin
dbms_lob.createtemporary(test_clob, TRUE, dbms_lob.SESSION);
dbms_lob.trim(test_clob, 0);
k := length(test_buf);
i := 0;
while i < 100000 loop
dbms_lob.writeappend(test_clob, k, test_buf);
i := i + k;
--dbms_output.put_line(i);
end loop;
i := 0;
while i < 60 loop
test_var := test_var || test_buf;
i := i + 1;
--dbms_output.put_line(i);
end loop;

test_clob_json := json();
test_clob_json.put('publish', true);
test_clob_json.put('issueDate', to_char(sysdate, 'YYYY-MM-DD"T"HH24:MI:SS'));
test_clob_json.put('subject', json_value(test_clob));

test_var_json := json();
test_var_json.put('publish', true);
test_var_json.put('issueDate', to_char(sysdate, 'YYYY-MM-DD"T"HH24:MI:SS'));
test_var_json.put('subject', test_var);

dbms_lob.createtemporary(json_clob, true, dbms_lob.SESSION);
dbms_lob.trim(json_clob, 0);
test_clob_json.to_clob(json_clob);
/* ignore, local procedure, not Oracle available
util_pkg.clob_to_os_utf(json_clob, 'json_test.json', 'TEMP_HOME');
*/

dbms_lob.freetemporary(test_clob);
dbms_lob.freetemporary(json_clob);

json_var := test_var_json.to_char();

end;
```

I can verify that the fork passes the test for the clob part.

However

a. the fork is nicely using CHAR sizes and is well written but I am afraid that there are issues with the VARCHAR2 version of the api now (uncovered by the second test) because the routines use a buffer of 8191 chars = 32764 bytes max and if escapeString is used then the escaped repr may explode to 8191 * 6 > 32764
this is the reason i restricted my solution to just 5000 chars "everywhere" and I even changed the 'if' in add_clob to "if(length(str) > 5000 - length(buf_str)) then"
(I think this is a very useful library and sometime the source should be refactored with shorter code and global variables for BUFFER_SIZE and AMOUNT and a thorough review that all cases are covered)

b. I wanted to push a merge as contribution to this project ...
please accept my merge and then change it :) :)