### PR TITLE
Code optimization

### DIFF
--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -50,8 +50,8 @@ package body "JSON_PRINTER" as
   -- associative array used inside escapeString to cache the escaped version of every character
   -- escaped so far  (example: char_map('"') contains the  '\"' string)
   -- (if the character does not need to be escaped, the character is stored unchanged in the array itself)
-  type Rmap_char is record(buf varchar2(40), len integer);
-  type Tmap_char_string is table of Rmap_char index by varchar2(1);                         
+  type Rmap_char is record(buf varchar2(40 char), len integer);
+  type Tmap_char_string is table of Rmap_char index by varchar2(1 char);                         
        char_map Tmap_char_string;                    
        -- since char_map the associative array is a global variable reused across multiple calls to escapeString,
        -- i need to be able to detect that the escape_solidus or ascii_output global parameters have been changed,
@@ -74,7 +74,7 @@ package body "JSON_PRINTER" as
   
   -- escapes a single character. 
   function escapeChar(ch char) return varchar2 deterministic is
-     result varchar2(20);
+     result varchar2(20 char);
   begin
       --backspace b = U+0008
       --formfeed  f = U+000C
@@ -104,9 +104,9 @@ package body "JSON_PRINTER" as
 
 
   function escapeString(str varchar2) return varchar2 as
-    sb varchar2(32000) := '';
+    sb varchar2(8191 char) := '';
     sb_length number:=0;
-    buf varchar2(40);
+    buf varchar2(40 char);
     buf_length number;
     ch varchar2(1 char);
   begin
@@ -197,10 +197,10 @@ package body "JSON_PRINTER" as
   end flush_clob;
   
   procedure add_escaped_string_to_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2, str in varchar2) as
-    sb varchar2(32767) := '';
+    sb varchar2(8191 char) := '';
     sb_length number:=0;
     new_sb_length number;
-    buf varchar2(40);
+    buf varchar2(40 char);
     buf_length integer;
     ch varchar2(1 char);
   begin
@@ -233,7 +233,7 @@ package body "JSON_PRINTER" as
       end;
       new_sb_length:=sb_length+buf_length;
       -- if length of result > 32767, then add it to clob and continue with new result
-      if new_sb_length>=32767 then
+      if new_sb_length>8191 then
         add_to_clob(buf_lob, buf_str, sb); --
         sb:=buf;
         sb_length:=buf_length;
@@ -271,8 +271,8 @@ package body "JSON_PRINTER" as
           if(elem.extended_str is not null) then --clob implementation
             declare
               offset number := 1;
-              v_str varchar(32767);
-              amount number := 32767;
+              v_str varchar(8191 char);
+              amount number := 8191;
             begin
               while(offset <= dbms_lob.getlength(elem.extended_str)) loop
                 dbms_lob.read(elem.extended_str, amount, offset, v_str);
@@ -335,8 +335,8 @@ package body "JSON_PRINTER" as
 
           declare
             offset number := 1;
-            v_str varchar(32767);
-            amount number := 32767;
+            v_str varchar(8191 char);
+            amount number := 8191;
           begin
 --            dbms_output.put_line('SIZE:'||dbms_lob.getlength(mem.extended_str));
             while(offset <= dbms_lob.getlength(mem.extended_str)) loop
@@ -396,7 +396,7 @@ package body "JSON_PRINTER" as
   end ppObj;
   
   procedure pretty_print(obj json, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as 
-    buf_str varchar2(32767);
+    buf_str varchar2(32767 byte);
     amount number := dbms_lob.getlength(buf);
   begin
     if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
@@ -408,7 +408,7 @@ package body "JSON_PRINTER" as
   end;
 
   procedure pretty_print_list(obj json_list, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as 
-    buf_str varchar2(32767);
+    buf_str varchar2(32767 byte);
     amount number := dbms_lob.getlength(buf);
   begin
     if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
@@ -422,7 +422,7 @@ package body "JSON_PRINTER" as
   end;
 
   procedure pretty_print_any(json_part json_value, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as
-    buf_str varchar2(32767) := '';
+    buf_str varchar2(32767 byte) := '';
     numbuf varchar2(4000);
     amount number := dbms_lob.getlength(buf);
   begin
@@ -443,8 +443,8 @@ package body "JSON_PRINTER" as
         if(json_part.extended_str is not null) then --clob implementation
           declare
             offset number := 1;
-            v_str varchar(32767);
-            amount number := 32767;
+            v_str varchar(8191 char);
+            amount number := 8191;
           begin
             while(offset <= dbms_lob.getlength(json_part.extended_str)) loop
               dbms_lob.read(json_part.extended_str, amount, offset, v_str);
@@ -585,7 +585,7 @@ package body "JSON_PRINTER" as
   end ppObj;
   
   function pretty_print(obj json, spaces boolean default true, line_length number default 0) return varchar2 as
-    buf varchar2(32767) := '';
+    buf varchar2(8191 char) := '';
   begin
     max_line_len := line_length;
     cur_line_len := 0;
@@ -594,7 +594,7 @@ package body "JSON_PRINTER" as
   end pretty_print;
 
   function pretty_print_list(obj json_list, spaces boolean default true, line_length number default 0) return varchar2 as
-    buf varchar2(32767);
+    buf varchar2(8191 char);
   begin
     max_line_len := line_length;
     cur_line_len := 0;
@@ -605,7 +605,7 @@ package body "JSON_PRINTER" as
   end;
 
   function pretty_print_any(json_part json_value, spaces boolean default true, line_length number default 0) return varchar2 as
-    buf varchar2(32767) := '';    
+    buf varchar2(8191 char) := '';    
   begin
     case json_part.get_type
       when 'number' then 
@@ -639,8 +639,8 @@ package body "JSON_PRINTER" as
     prev number := 1;
     indx number := 1;
     size_of_nl number := lengthb(delim);
-    v_str varchar2(32767);
-    amount number := 32767;
+    v_str varchar2(8191 char);
+    amount number := 8191;
   begin
     if(jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
     while(indx != 0) loop
@@ -650,7 +650,7 @@ package body "JSON_PRINTER" as
       
       if(indx = 0) then
         --emit from prev to end;
-        amount := 32767;
+        amount := 8191;
  --       dbms_output.put_line(' mycloblen ' || dbms_lob.getlength(my_clob));
         loop
           dbms_lob.read(my_clob, amount, prev, v_str);
@@ -660,8 +660,8 @@ package body "JSON_PRINTER" as
         end loop;
       else 
         amount := indx - prev;
-        if(amount > 32767) then 
-          amount := 32767;
+        if(amount > 8191) then 
+          amount := 8191;
 --          dbms_output.put_line(' mycloblen ' || dbms_lob.getlength(my_clob));
           loop
             dbms_lob.read(my_clob, amount, prev, v_str);
@@ -669,7 +669,7 @@ package body "JSON_PRINTER" as
             prev := prev+amount-1;
             amount := indx - prev;
             exit when prev >= indx - 1;
-            if(amount > 32767) then amount := 32767; end if;
+            if(amount > 8191) then amount := 8191; end if;
           end loop;
           prev := indx + size_of_nl;
         else 

--- a/src/json_printer.sql
+++ b/src/json_printer.sql
@@ -42,34 +42,34 @@ create or replace
 package body "JSON_PRINTER" as
   max_line_len number := 0;
   cur_line_len number := 0;
-           
-  
+
+
   -- associative array used inside escapeString to cache the escaped version of every character
   -- escaped so far  (example: char_map('"') contains the  '\"' string)
   -- (if the character does not need to be escaped, the character is stored unchanged in the array itself)
-  type Rmap_char is record(buf varchar2(40), len integer);
-  type Tmap_char_string is table of Rmap_char index by varchar2(1 char); /* index by unicode char */
-       char_map Tmap_char_string;                    
+    --type Rmap_char is record(buf varchar2(40), len integer);
+  type Tmap_char_string is table of varchar2(40) index by varchar2(1 char); /* index by unicode char */
+       char_map Tmap_char_string;
        -- since char_map the associative array is a global variable reused across multiple calls to escapeString,
        -- i need to be able to detect that the escape_solidus or ascii_output global parameters have been changed,
        -- in order to clear it and avoid using escape sequences that have been cached using the previous values
        char_map_escape_solidus boolean := escape_solidus;
        char_map_ascii_output boolean := ascii_output;
 
-  
+
   function llcheck(str in varchar2) return varchar2 as
   begin
     --dbms_output.put_line(cur_line_len || ' : '|| str);
     if(max_line_len > 0 and length(str)+cur_line_len > max_line_len) then
       cur_line_len := length(str);
       return newline_char || str;
-    else 
+    else
       cur_line_len := cur_line_len + length(str);
       return str;
     end if;
-  end llcheck;  
-  
-  -- escapes a single character. 
+  end llcheck;
+
+  -- escapes a single character.
   function escapeChar(ch char) return varchar2 deterministic is
      result varchar2(20);
   begin
@@ -79,7 +79,7 @@ package body "JSON_PRINTER" as
       --carret    r = U+000D
       --tabulator t = U+0009
       result := ch;
-      
+
       case ch
       when chr( 8) then result := '\b';
       when chr( 9) then result := '\t';
@@ -91,20 +91,18 @@ package body "JSON_PRINTER" as
       when chr(92) then result := '\\';
       else if(ascii(ch) < 32) then
              result :=  '\u'||replace(substr(to_char(ascii(ch), 'XXXX'),2,4), ' ', '0');
-        elsif (ascii_output) then 
+        elsif (ascii_output) then
              result := replace(asciistr(ch), '\', '\u');
         end if;
-      end case;    
-      return result;  
+      end case;
+      return result;
   end;
 
 
 
   function escapeString(str varchar2) return varchar2 as
-    sb varchar2(32767) := '';
-    sb_length number:=0;
+    sb varchar2(32767 byte) := '';
     buf varchar2(40);
-    buf_length number;
     ch varchar2(1 char); /* unicode char */
   begin
     if(str is null) then return ''; end if;
@@ -121,20 +119,13 @@ package body "JSON_PRINTER" as
     for i in 1 .. length(str) loop
       ch := substr(str, i, 1 ) ;
 
-      declare
-        current_map Rmap_char;
       begin
          -- it this char has already been processed, I have cached its escaped value
-         current_map:=char_map(ch);
-         buf := current_map.buf;
-         buf_length:=current_map.len;
+         buf:=char_map(ch);
       exception when no_Data_found then
          -- otherwise, i convert the value and add it to the cache
          buf := escapeChar(ch);
-         buf_length:=length(buf);
-         current_map.buf:=buf;
-         current_map.len:=buf_length;
-         char_map(ch) := current_map;
+         char_map(ch) := buf;
       end;
 
       sb := sb || buf;
@@ -151,8 +142,8 @@ package body "JSON_PRINTER" as
 /*  function get_schema return varchar2 as
   begin
     return sys_context('userenv', 'current_schema');
-  end;  
-*/  
+  end;
+*/
   function tab(indent number, spaces boolean) return varchar2 as
     i varchar(200) := '';
   begin
@@ -160,7 +151,7 @@ package body "JSON_PRINTER" as
     for x in 1 .. indent loop i := i || indent_string; end loop;
     return i;
   end;
-  
+
   function getCommaSep(spaces boolean) return varchar2 as
   begin
     if(spaces) then return ', '; else return ','; end if;
@@ -170,7 +161,7 @@ package body "JSON_PRINTER" as
   begin
     if(spaces) then
       return llcheck('"'||escapeString(mem.mapname)||'"') || llcheck(' : ');
-    else 
+    else
       return llcheck('"'||escapeString(mem.mapname)||'"') || llcheck(':');
     end if;
   end;
@@ -184,7 +175,7 @@ package body "JSON_PRINTER" as
       buf_str := str;
     else
       buf_str := buf_str || str;
-    end if;  
+    end if;
   end add_to_clob;
 
   procedure flush_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2) as
@@ -192,14 +183,14 @@ package body "JSON_PRINTER" as
 --    dbms_lob.append(buf_lob, buf_str);
     dbms_lob.writeappend(buf_lob, length(buf_str), buf_str);
   end flush_clob;
-  
+  /*
   procedure add_escaped_string_to_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2, str in varchar2) as
     sb varchar2(32767) := '';
     sb_length number:=0;
     new_sb_length number;
     buf varchar2(40);
     buf_length integer;
-    ch varchar2(1 char); /* unicode char */
+    ch varchar2(1 char);
   begin
     if(str is null) then return; end if;
     -- clear the cache if global parameters have been changed
@@ -242,8 +233,38 @@ package body "JSON_PRINTER" as
     -- add rest ob result to clob
     add_to_clob(buf_lob, buf_str, sb);
   end;
-  
+  */
   procedure ppObj(obj json, indent number, buf in out nocopy clob, spaces boolean, buf_str in out nocopy varchar2);
+
+  procedure ppString(elem json_value, buf in out nocopy clob, buf_str in out nocopy varchar2) is
+    offset number := 1;
+    v_str varchar(5000 char);
+    amount number := 5000; /*chunk size for use in escapeString. Maximum escaped unicode string size for chunk may be 6 one-byte chars * 5000 chunk size in multi-byte chars = 30000 1-byte chars. Maximum value may be 32767 1-byte chars */
+  begin
+    add_to_clob(buf, buf_str, case when elem.num = 1 then '"' else '/**/' end);
+    if(elem.extended_str is not null) then --clob implementation
+        while(offset <= dbms_lob.getlength(elem.extended_str)) loop
+          dbms_lob.read(elem.extended_str, amount, offset, v_str);
+          if(elem.num = 1) then
+            add_to_clob(buf, buf_str, escapeString(v_str));
+          else
+            add_to_clob(buf, buf_str, v_str);
+          end if;
+          offset := offset + amount;
+        end loop;
+    else
+        if(elem.num = 1) then
+            while(offset<length(elem.str)) loop
+                v_str:=substr(elem.str, offset, amount);
+                add_to_clob(buf, buf_str, escapeString(v_str));
+                offset := offset + amount;
+            end loop;
+        else
+            add_to_clob(buf, buf_str, elem.str);
+        end if;
+    end if;
+    add_to_clob(buf, buf_str, case when elem.num = 1 then '"' else '/**/' end || newline_char);
+  end;
 
   procedure ppEA(input json_list, indent number, buf in out nocopy clob, spaces boolean, buf_str in out nocopy varchar2) as
     elem json_value;
@@ -265,33 +286,7 @@ package body "JSON_PRINTER" as
           end if;
           add_to_clob(buf, buf_str, llcheck(numbuf));
         when 'string' then
-          add_to_clob(buf, buf_str, case when elem.num = 1 then '"' else '/**/' end);
-          if(elem.extended_str is not null) then --clob implementation
-            declare
-              offset number := 1;
-              v_str varchar(32767);
-              amount number := 5000; /* max escaped unicode string size */
-            begin
-              while(offset <= dbms_lob.getlength(elem.extended_str)) loop
-                dbms_lob.read(elem.extended_str, amount, offset, v_str);
-                if(elem.num = 1) then
-                  add_to_clob(buf, buf_str, escapeString(v_str));
-                  -- add_escaped_string_to_clob(buf, buf_str, v_str);
-                else
-                  add_to_clob(buf, buf_str, v_str);
-                end if;
-                offset := offset + amount;
-              end loop;
-            end;
-          else
-            --if(elem.num = 1) then
-              --add_to_clob(buf, buf_str, llcheck('"'||escapeString(elem.get_string)||'"'));
-              add_escaped_string_to_clob(buf, buf_str, elem.get_string);
-            --else
-            --  add_to_clob(buf, buf_str, llcheck('/**/'||elem.get_string||'/**/'));
-            --end if;
-          end if;
-          add_to_clob(buf, buf_str, case when elem.num = 1 then '"' else '/**/' end || newline_char);
+          ppString(elem, buf, buf_str);
         when 'bool' then
           if(elem.get_bool) then
             add_to_clob(buf, buf_str, llcheck('true'));
@@ -328,39 +323,7 @@ package body "JSON_PRINTER" as
         end if;
         add_to_clob(buf, buf_str, llcheck(numbuf));
       when 'string' then
-        add_to_clob(buf, buf_str, case when mem.num = 1 then '"' else '/**/' end);
-        if(mem.extended_str is not null) then --clob implementation
-
-          declare
-            offset number := 1;
-            v_str varchar(32767);
-            amount number := 5000; /* max escaped unicode string size */
-          begin
---            dbms_output.put_line('SIZE:'||dbms_lob.getlength(mem.extended_str));
-            while(offset <= dbms_lob.getlength(mem.extended_str)) loop
---            dbms_output.put_line('OFFSET:'||offset);
- --             v_str := dbms_lob.substr(mem.extended_str, 8192, offset);
-              dbms_lob.read(mem.extended_str, amount, offset, v_str);
---            dbms_output.put_line('VSTR_SIZE:'||length(v_str));
-              if(mem.num = 1) then
-                add_to_clob(buf, buf_str, escapeString(v_str));
-                --add_escaped_string_to_clob(buf, buf_str, v_str);
-              else
-                add_to_clob(buf, buf_str, v_str);
-              end if;
-              offset := offset + amount;
-            end loop;
-          end;
-
-        else
-         -- if(mem.num = 1) then
-            -- add_to_clob(buf, buf_str, llcheck('"'||escapeString(mem.get_string)||'"'));
-            add_escaped_string_to_clob(buf, buf_str, mem.get_string);
-         -- else
-         --   add_to_clob(buf, buf_str, llcheck('/**/'||mem.get_string||'/**/'));
-         -- end if;
-        end if;
-        add_to_clob(buf, buf_str, case when mem.num = 1 then '"' else '/**/' end || newline_char);
+        ppString(mem, buf, buf_str);
       when 'bool' then
         if(mem.get_bool) then
           add_to_clob(buf, buf_str, llcheck('true'));
@@ -384,37 +347,37 @@ package body "JSON_PRINTER" as
     add_to_clob(buf, buf_str, llcheck('{') || newline(spaces));
     for m in 1 .. obj.json_data.count loop
       ppMem(obj.json_data(m), indent+1, buf, spaces, buf_str);
-      if(m != obj.json_data.count) then 
+      if(m != obj.json_data.count) then
         add_to_clob(buf, buf_str, llcheck(',') || newline(spaces));
-      else 
-        add_to_clob(buf, buf_str, newline(spaces)); 
+      else
+        add_to_clob(buf, buf_str, newline(spaces));
       end if;
     end loop;
     add_to_clob(buf, buf_str, llcheck(tab(indent, spaces)) || llcheck('}')); -- || chr(13);
   end ppObj;
-  
-  procedure pretty_print(obj json, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as 
+
+  procedure pretty_print(obj json, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as
     buf_str varchar2(32767);
     amount number := dbms_lob.getlength(buf);
   begin
     if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
-    
+
     max_line_len := line_length;
     cur_line_len := 0;
-    ppObj(obj, 0, buf, spaces, buf_str);  
+    ppObj(obj, 0, buf, spaces, buf_str);
     flush_clob(buf, buf_str);
   end;
 
-  procedure pretty_print_list(obj json_list, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as 
+  procedure pretty_print_list(obj json_list, spaces boolean default true, buf in out nocopy clob, line_length number default 0, erase_clob boolean default true) as
     buf_str varchar2(32767);
     amount number := dbms_lob.getlength(buf);
   begin
     if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
-    
+
     max_line_len := line_length;
     cur_line_len := 0;
     add_to_clob(buf, buf_str, llcheck('['));
-    ppEA(obj, 0, buf, spaces, buf_str);  
+    ppEA(obj, 0, buf, spaces, buf_str);
     add_to_clob(buf, buf_str, llcheck(']'));
     flush_clob(buf, buf_str);
   end;
@@ -437,35 +400,9 @@ package body "JSON_PRINTER" as
         end if;
         add_to_clob(buf, buf_str, numbuf);
       when 'string' then
-        add_to_clob(buf, buf_str, case when json_part.num = 1 then '"' else '/**/' end);
-        if(json_part.extended_str is not null) then --clob implementation
-          declare
-            offset number := 1;
-            v_str varchar(32767);
-            amount number := 5000; /* max escaped unicode string size */
-          begin
-            while(offset <= dbms_lob.getlength(json_part.extended_str)) loop
-              dbms_lob.read(json_part.extended_str, amount, offset, v_str);
-              if(json_part.num = 1) then
-                add_to_clob(buf, buf_str, escapeString(v_str));
-                --add_escaped_string_to_clob(buf, buf_str, v_str);
-              else
-                add_to_clob(buf, buf_str, v_str);
-              end if;
-              offset := offset + amount;
-            end loop;
-          end;
-        else
-          --if(json_part.num = 1) then
-            --add_to_clob(buf, buf_str, llcheck('"'||escapeString(json_part.get_string)||'"'));
-            add_escaped_string_to_clob(buf, buf_str, json_part.get_string);
-          --else
-          --  add_to_clob(buf, buf_str, llcheck('/**/'||json_part.get_string||'/**/'));
-          --end if;
-        end if;
-        add_to_clob(buf, buf_str, case when json_part.num = 1 then '"' else '/**/' end);
+        ppString(json_part, buf, buf_str);
       when 'bool' then
-          if(json_part.get_bool) then
+        if(json_part.get_bool) then
           add_to_clob(buf, buf_str, 'true');
         else
           add_to_clob(buf, buf_str, 'false');
@@ -490,7 +427,7 @@ package body "JSON_PRINTER" as
   procedure ppObj(obj json, indent number, buf in out nocopy varchar2, spaces boolean);
 
   procedure ppEA(input json_list, indent number, buf in out varchar2, spaces boolean) as
-    elem json_value; 
+    elem json_value;
     arr json_value_array := input.list_data;
     str varchar2(400);
   begin
@@ -498,23 +435,23 @@ package body "JSON_PRINTER" as
       elem := arr(y);
       if(elem is not null) then
       case elem.get_type
-        when 'number' then 
+        when 'number' then
           str := '';
           if (elem.get_number < 1 and elem.get_number > 0) then str := '0'; end if;
-          if (elem.get_number < 0 and elem.get_number > -1) then 
+          if (elem.get_number < 0 and elem.get_number > -1) then
             str := '-0' || substr(to_char(elem.get_number, 'TM9', 'NLS_NUMERIC_CHARACTERS=''.,'''),2);
           else
             str := str || to_char(elem.get_number, 'TM9', 'NLS_NUMERIC_CHARACTERS=''.,''');
           end if;
           buf := buf || llcheck(str);
-        when 'string' then 
-          if(elem.num = 1) then 
+        when 'string' then
+          if(elem.num = 1) then
             buf := buf || llcheck('"'||escapeString(elem.get_string)||'"');
-          else 
+          else
             buf := buf || llcheck('/**/'||elem.get_string||'/**/');
           end if;
         when 'bool' then
-          if(elem.get_bool) then           
+          if(elem.get_bool) then
             buf := buf || llcheck('true');
           else
             buf := buf || llcheck('false');
@@ -539,24 +476,24 @@ package body "JSON_PRINTER" as
   begin
     buf := buf || llcheck(tab(indent, spaces)) || getMemName(mem, spaces);
     case mem.get_type
-      when 'number' then 
+      when 'number' then
         if (mem.get_number < 1 and mem.get_number > 0) then str := '0'; end if;
-        if (mem.get_number < 0 and mem.get_number > -1) then 
+        if (mem.get_number < 0 and mem.get_number > -1) then
           str := '-0' || substr(to_char(mem.get_number, 'TM9', 'NLS_NUMERIC_CHARACTERS=''.,'''),2);
         else
           str := str || to_char(mem.get_number, 'TM9', 'NLS_NUMERIC_CHARACTERS=''.,''');
         end if;
         buf := buf || llcheck(str);
-      when 'string' then 
-        if(mem.num = 1) then 
+      when 'string' then
+        if(mem.num = 1) then
           buf := buf || llcheck('"'||escapeString(mem.get_string)||'"');
-        else 
+        else
           buf := buf || llcheck('/**/'||mem.get_string||'/**/');
         end if;
       when 'bool' then
-        if(mem.get_bool) then 
+        if(mem.get_bool) then
           buf := buf || llcheck('true');
-        else 
+        else
           buf := buf || llcheck('false');
         end if;
       when 'null' then
@@ -570,7 +507,7 @@ package body "JSON_PRINTER" as
       else buf := buf || llcheck(mem.get_type); /* should never happen */
     end case;
   end ppMem;
-  
+
   procedure ppObj(obj json, indent number, buf in out nocopy varchar2, spaces boolean) as
   begin
     buf := buf || llcheck('{') || newline(spaces);
@@ -581,7 +518,7 @@ package body "JSON_PRINTER" as
     end loop;
     buf := buf || llcheck(tab(indent, spaces)) || llcheck('}'); -- || chr(13);
   end ppObj;
-  
+
   function pretty_print(obj json, spaces boolean default true, line_length number default 0) return varchar2 as
     buf varchar2(32767) := '';
   begin
@@ -603,25 +540,25 @@ package body "JSON_PRINTER" as
   end;
 
   function pretty_print_any(json_part json_value, spaces boolean default true, line_length number default 0) return varchar2 as
-    buf varchar2(32767) := '';    
+    buf varchar2(32767) := '';
   begin
     case json_part.get_type
-      when 'number' then 
+      when 'number' then
         if (json_part.get_number() < 1 and json_part.get_number() > 0) then buf := buf || '0'; end if;
-        if (json_part.get_number() < 0 and json_part.get_number() > -1) then 
-          buf := buf || '-0'; 
+        if (json_part.get_number() < 0 and json_part.get_number() > -1) then
+          buf := buf || '-0';
           buf := buf || substr(to_char(json_part.get_number(), 'TM9', 'NLS_NUMERIC_CHARACTERS=''.,'''),2);
         else
           buf := buf || to_char(json_part.get_number(), 'TM9', 'NLS_NUMERIC_CHARACTERS=''.,''');
         end if;
-      when 'string' then 
-        if(json_part.num = 1) then 
+      when 'string' then
+        if(json_part.num = 1) then
           buf := buf || '"'||escapeString(json_part.get_string)||'"';
-        else 
+        else
           buf := buf || '/**/'||json_part.get_string||'/**/';
         end if;
       when 'bool' then
-      	if(json_part.get_bool) then buf := 'true'; else buf := 'false'; end if;
+        if(json_part.get_bool) then buf := 'true'; else buf := 'false'; end if;
       when 'null' then
         buf := 'null';
       when 'array' then
@@ -632,8 +569,8 @@ package body "JSON_PRINTER" as
     end case;
     return buf;
   end;
-  
-  procedure dbms_output_clob(my_clob clob, delim varchar2, jsonp varchar2 default null) as 
+
+  procedure dbms_output_clob(my_clob clob, delim varchar2, jsonp varchar2 default null) as
     prev number := 1;
     indx number := 1;
     size_of_nl number := lengthb(delim);
@@ -645,7 +582,7 @@ package body "JSON_PRINTER" as
       --read every line
       indx := dbms_lob.instr(my_clob, delim, prev+1);
  --     dbms_output.put_line(prev || ' to ' || indx);
-      
+
       if(indx = 0) then
         --emit from prev to end;
         amount := 8191; /* max unicode chars */
@@ -656,7 +593,7 @@ package body "JSON_PRINTER" as
           prev := prev+amount-1;
           exit when prev >= dbms_lob.getlength(my_clob);
         end loop;
-      else 
+      else
         amount := indx - prev;
         if(amount > 8191) then /* max unicode chars */
           amount := 8191; /* max unicode chars */
@@ -670,21 +607,21 @@ package body "JSON_PRINTER" as
             if(amount > 8191) then amount := 8191; end if; /* max unicode chars */
           end loop;
           prev := indx + size_of_nl;
-        else 
+        else
           dbms_lob.read(my_clob, amount, prev, v_str);
-          dbms_output.put_line(v_str);     
+          dbms_output.put_line(v_str);
           prev := indx + size_of_nl;
         end if;
       end if;
-    
+
     end loop;
     if(jsonp is not null) then dbms_output.put_line(')'); end if;
 
 /*    while (amount != 0) loop
       indx := dbms_lob.instr(my_clob, delim, prev+1);
-      
+
 --      dbms_output.put_line(prev || ' to ' || indx);
-      if(indx = 0) then 
+      if(indx = 0) then
         indx := dbms_lob.getlength(my_clob)+1;
       end if;
       if(indx-prev > 32767) then
@@ -704,7 +641,7 @@ package body "JSON_PRINTER" as
   end;
 
 
-/*  procedure dbms_output_clob(my_clob clob, delim varchar2, jsonp varchar2 default null) as 
+/*  procedure dbms_output_clob(my_clob clob, delim varchar2, jsonp varchar2 default null) as
     prev number := 1;
     indx number := 1;
     size_of_nl number := lengthb(delim);
@@ -714,18 +651,18 @@ package body "JSON_PRINTER" as
     if(jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
     while (indx != 0) loop
       indx := dbms_lob.instr(my_clob, delim, prev+1);
-      
+
 --      dbms_output.put_line(prev || ' to ' || indx);
       if(indx-prev > 32767) then
         indx := prev+32767;
       end if;
 --      dbms_output.put_line(prev || ' to ' || indx);
       --substr doesnt work properly on all platforms! (come on oracle - error on Oracle VM for virtualbox)
-      if(indx = 0) then 
+      if(indx = 0) then
 --        dbms_output.put_line(dbms_lob.substr(my_clob, dbms_lob.getlength(my_clob)-prev+size_of_nl, prev));
         amount := dbms_lob.getlength(my_clob)-prev+size_of_nl;
         dbms_lob.read(my_clob, amount, prev, v_str);
-      else 
+      else
 --        dbms_output.put_line(dbms_lob.substr(my_clob, indx-prev, prev));
         amount := indx-prev;
 --        dbms_output.put_line('amount'||amount);
@@ -737,8 +674,8 @@ package body "JSON_PRINTER" as
     end loop;
     if(jsonp is not null) then dbms_output.put_line(')'); end if;
   end;
-*/  
-  procedure htp_output_clob(my_clob clob, jsonp varchar2 default null) as 
+*/
+  procedure htp_output_clob(my_clob clob, jsonp varchar2 default null) as
     /*amount number := 4096;
     pos number := 1;
     len number;
@@ -746,15 +683,15 @@ package body "JSON_PRINTER" as
     l_amt    number default 30;
     l_off   number default 1;
     l_str   varchar2(4096);
-    
+
   begin
     if(jsonp is not null) then htp.prn(jsonp||'('); end if;
-    
+
     begin
       loop
         dbms_lob.read( my_clob, l_amt, l_off, l_str );
 
-        -- it is vital to use htp.PRN to avoid 
+        -- it is vital to use htp.PRN to avoid
         -- spurious line feeds getting added to your
         -- document
         htp.prn( l_str  );
@@ -764,13 +701,13 @@ package body "JSON_PRINTER" as
     exception
       when no_data_found then NULL;
     end;
-        
+
     /*
     len := dbms_lob.getlength(my_clob);
-    
+
     while(pos < len) loop
       htp.prn(dbms_lob.substr(my_clob, amount, pos)); -- should I replace substr with dbms_lob.read?
-      --dbms_output.put_line(dbms_lob.substr(my_clob, amount, pos)); 
+      --dbms_output.put_line(dbms_lob.substr(my_clob, amount, pos));
       pos := pos + amount;
     end loop;
     */

--- a/src/json_value_body.typ
+++ b/src/json_value_body.typ
@@ -24,11 +24,12 @@ type body json_value as
   end json_value;
 
   constructor function json_value(str clob, esc boolean default true) return self as result as
-    amount number := 32767;
+    amount number:=8191;
   begin
     self.typeval := 3;
     if(esc) then self.num := 1; else self.num := 0; end if; --message to pretty printer
-    if(dbms_lob.getlength(str) > 32767) then
+    --if length of str more than 8191 chars, store it in extended_str, may be in bytes it 8191*4.
+    if(dbms_lob.getlength(str) > 8191) then
       extended_str := str;
     end if;
     -- GHS 20120615: Added IF structure to handle null clobs

--- a/src/json_value_body.typ
+++ b/src/json_value_body.typ
@@ -24,12 +24,11 @@ type body json_value as
   end json_value;
 
   constructor function json_value(str clob, esc boolean default true) return self as result as
-    amount number:=8191;
+    amount number := 5000; /* for Unicode text, varchar2 'self.str' not exceed 5000 chars, does not limit size of data */
   begin
     self.typeval := 3;
     if(esc) then self.num := 1; else self.num := 0; end if; --message to pretty printer
-    --if length of str more than 8191 chars, store it in extended_str, may be in bytes it 8191*4.
-    if(dbms_lob.getlength(str) > 8191) then
+    if(dbms_lob.getlength(str) > amount) then
       extended_str := str;
     end if;
     -- GHS 20120615: Added IF structure to handle null clobs


### PR DESCRIPTION
Hi, guys.
In this patch I replace procedure ```add_escaped_string_to_clob``` back to ```add_to_clob``` and remove unused variables in ```escapeString``` function and in type ```Tmap_char_string```. For correct escaping string values with null ```extended_str``` (set as varchar2, not clob) used loop with 5000 char chunk. Code for print to clob string values in ppEA, ppMem and pretty_print_any procedures is the same. I moved this code to ```ppString``` procedure.

Functions and procedures for printing result json to varchar2 fill buffer variable thrue ```add_buf``` procedure where length of result json controlled and when it more than 32767 bytes, procedure raise exception with error ```ORA-20001: Length of result JSON more than 32767 bytes. Use to_clob() procedures ```.
Code for printing string variables in that functions moved to ```ppString``` procedure. This procedure print value from clob variable (extended_str) too for case when we have string more than 5000 english 1-byte chars, putted thrue code ```json.put('tag',json_value(clob_value))```, when escaped and not escaped values is the same. For correct escaping string values in ```escapeString``` used loop with 5000 char chunk.

@dsnz , please, can you test this changes?