### PR TITLE
xml generation fails when json field value has null values i.e. like ""

### DIFF
--- a/src/addons/json_xml.sql
+++ b/src/addons/json_xml.sql
@@ -134,7 +134,7 @@ package body json_xml as
         toString(v_value, nvl(tagname, 'array'), xmlstr, xmlbuf);   
       end loop;
     else 
-      add_to_clob(xmlstr, xmlbuf, '<' || tagname || '>'||escapeStr(obj.value_of())||'</' || tagname || '>');
+      add_to_clob(xmlstr, xmlbuf, '<' || tagname || '>'||case when obj.value_of() is  not null then escapeStr(obj.value_of()) end ||'</' || tagname || '>');
     end if;
   end toString;
 


### PR DESCRIPTION
xml_json fails with exception when json value looks like "". It that case we just need to xml empty tags like <tag></tag>