### PR TITLE
Support for properties with '-' character.

### DIFF
--- a/src/json_ext.sql
+++ b/src/json_ext.sql
@@ -155,13 +155,13 @@ create or replace package body json_ext as
       if(buf = '.') then
         next_char();
         if(buf is null) then raise_application_error(-20110, 'JSON Path parse error: . is not a valid json_path end'); end if;
-        if(not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if(not regexp_like(buf, '^[[:alnum:]-\_ ]+', 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
         
         if(build_path != '[') then build_path := build_path || ','; end if;
         build_path := build_path || '"';
-        while(regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while(regexp_like(buf, '^[[:alnum:]-\_ ]+', 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;
@@ -203,11 +203,11 @@ create or replace package body json_ext as
         next_char();
         skipws();
       elsif(build_path = '[') then
-        if(not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if(not regexp_like(buf, '^[[:alnum:]-\_ ]+', 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
         build_path := build_path || '"';
-        while(regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while(regexp_like(buf, '^[[:alnum:]-\_ ]+', 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;


### PR DESCRIPTION
Currently there are APIs that return a json that has properties with the character '-' in the name, for example {"my-property": "myvalue"}. When I try to execute JSON_EXT.GET_STRING (MY_JSON, 'my-property') the following error occurs.

**ORA-20110: JSON Path parse error: expected . or [ found - at position 4**

To solve this, I added the '-' character to the regular expression.
An API example that has the '-' character in its properties would be Hubspot API.
Https://developers.hubspot.com/docs/methods/contacts/get_contacts. 

Regards.
