### PR TITLE
add ignore_nulls parameter

### DIFF
--- a/src/addons/json_dyn.sql
+++ b/src/addons/json_dyn.sql
@@ -21,6 +21,7 @@ create or replace package json_dyn authid current_user as
   THE SOFTWARE.
   */
 
+  include_nulls          boolean not null := true;
   null_as_empty_string   boolean not null := true;  --varchar2
   include_dates          boolean not null := true;  --date
   include_clobs          boolean not null := true;
@@ -143,10 +144,12 @@ package body json_dyn as
         when l_dtbl(i).col_type in (1,96) then -- varchar2
           dbms_sql.column_value(l_cur,i,l_val);
           if(l_val is null) then
-            if(null_as_empty_string) then
-              inner_obj.put(l_dtbl(i).col_name, ''); --treatet as emptystring?
-            else
-              inner_obj.put(l_dtbl(i).col_name, json_value.makenull); --null
+            if(include_nulls) then
+              if(null_as_empty_string) then
+                inner_obj.put(l_dtbl(i).col_name, ''); --treatet as emptystring?
+              else
+                inner_obj.put(l_dtbl(i).col_name, json_value.makenull); --null
+              end if;
             end if;
           else
             inner_obj.put(l_dtbl(i).col_name, json_value(l_val)); --null
@@ -155,31 +158,39 @@ package body json_dyn as
         --handling number types
         when l_dtbl(i).col_type = 2 then -- number
           dbms_sql.column_value(l_cur,i,l_val);
-          conv := l_val;
-          inner_obj.put(l_dtbl(i).col_name, conv);
+          if(l_val is not null or include_nulls) then
+            conv := l_val;
+            inner_obj.put(l_dtbl(i).col_name, conv);
+          end if;
           -- dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'number ' ||l_dtbl(i).col_type);
         when l_dtbl(i).col_type = 12 then -- date
           if(include_dates) then
             dbms_sql.column_value(l_cur,i,read_date);
-            inner_obj.put(l_dtbl(i).col_name, json_ext.to_json_value(read_date));
+            if(read_date is not null or include_nulls) then
+              inner_obj.put(l_dtbl(i).col_name, json_ext.to_json_value(read_date));
+            end if;
           end if;
           --dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'date ' ||l_dtbl(i).col_type);
         when l_dtbl(i).col_type = 112 then --clob
           if(include_clobs) then
             dbms_sql.column_value(l_cur,i,read_clob);
-            inner_obj.put(l_dtbl(i).col_name, json_value(read_clob));
+            if(read_clob is not null or include_nulls) then
+              inner_obj.put(l_dtbl(i).col_name, json_value(read_clob));
+            end if;
           end if;
         when l_dtbl(i).col_type = 113 then --blob
           if(include_blobs) then
             dbms_sql.column_value(l_cur,i,read_blob);
-            if(dbms_lob.getlength(read_blob) > 0) then
-              inner_obj.put(l_dtbl(i).col_name, json_ext.encode(read_blob));
-            else
-              inner_obj.put(l_dtbl(i).col_name, json_value.makenull);
+            if(read_blob is not null or include_nulls) then
+              if(dbms_lob.getlength(read_blob) > 0) then
+                inner_obj.put(l_dtbl(i).col_name, json_ext.encode(read_blob));
+              else
+                inner_obj.put(l_dtbl(i).col_name, json_value.makenull);
+              end if;
             end if;
           end if;
-
-        else null; --discard other types
+        else 
+          dbms_output.put_line('ignoring type '||l_dtbl(i).col_type);
         end case;
       end loop;
       outer_list.append(inner_obj.to_json_value);


### PR DESCRIPTION
I added an `include_nulls` parameter to `JSON_DYN` to filter out nulls in the resultant JSON.