### PR TITLE
Added constructors from BLOBs (to use with JSON bodies provided by ORDS)

### DIFF
--- a/src/pljson.type.decl.sql
+++ b/src/pljson.type.decl.sql
@@ -104,9 +104,10 @@ create or replace type pljson force under pljson_element (
    * <p>Construct a <code>pljson</code> instance from a given BLOB of JSON.</p>
    *
    * @param str The BLOB to parse into a <code>pljson</code> object.
+   * @param charset The character set of the BLOB data (defaults to UTF-8).
    * @return A <code>pljson</code> instance.
    */
-  constructor function pljson(str in blob) return self as result,
+  constructor function pljson(str in blob, charset varchar2 default 'UTF8') return self as result,
   
   /**
    * <p>Create a new <code>pljson</code> object from a current <code>pljson_value</code>.

--- a/src/pljson.type.decl.sql
+++ b/src/pljson.type.decl.sql
@@ -101,6 +101,14 @@ create or replace type pljson force under pljson_element (
   constructor function pljson(str in clob) return self as result,
   
   /**
+   * <p>Construct a <code>pljson</code> instance from a given BLOB of JSON.</p>
+   *
+   * @param str The BLOB to parse into a <code>pljson</code> object.
+   * @return A <code>pljson</code> instance.
+   */
+  constructor function pljson(str in blob) return self as result,
+  
+  /**
    * <p>Create a new <code>pljson</code> object from a current <code>pljson_value</code>.
    *
    * <pre>

--- a/src/pljson.type.impl.sql
+++ b/src/pljson.type.impl.sql
@@ -44,6 +44,16 @@ create or replace type body pljson as
     return;
   end;
   
+  constructor function pljson(str in blob) return self as result as
+    c_str clob;
+  begin
+    pljson_ext.blob2clob(str, c_str);
+    self := pljson_parser.parser(c_str);
+    self.check_for_duplicate := 1;
+    dbms_lob.freetemporary(c_str);
+    return;
+  end;
+  
   constructor function pljson(elem pljson_value) return self as result as
   begin
     self := treat(elem.object_or_array as pljson);

--- a/src/pljson.type.impl.sql
+++ b/src/pljson.type.impl.sql
@@ -44,10 +44,10 @@ create or replace type body pljson as
     return;
   end;
   
-  constructor function pljson(str in blob) return self as result as
+  constructor function pljson(str in blob, charset varchar2 default 'UTF8') return self as result as
     c_str clob;
   begin
-    pljson_ext.blob2clob(str, c_str);
+    pljson_ext.blob2clob(str, c_str, charset);
     self := pljson_parser.parser(c_str);
     self.check_for_duplicate := 1;
     dbms_lob.freetemporary(c_str);

--- a/src/pljson_ext.decl.sql
+++ b/src/pljson_ext.decl.sql
@@ -98,7 +98,7 @@ create or replace package pljson_ext as
   /*
     implemented as a procedure to force you to declare the CLOB so you can free it later
   */
-  procedure blob2clob(b blob, c out clob);
+  procedure blob2clob(b blob, c out clob, charset varchar2 default 'UTF8');
   
 end pljson_ext;
 /

--- a/src/pljson_ext.decl.sql
+++ b/src/pljson_ext.decl.sql
@@ -95,5 +95,10 @@ create or replace package pljson_ext as
   function encode(binarydata blob) return pljson_value;
   function decode(v pljson_value) return blob;
   
+  /*
+    implemented as a procedure to force you to declare the CLOB so you can free it later
+  */
+  procedure blob2clob(b blob, c out clob);
+  
 end pljson_ext;
 /

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -725,7 +725,7 @@ create or replace package body pljson_ext as
     
   end decode;
   
-  procedure blob2clob(b blob, c out clob) as
+  procedure blob2clob(b blob, c out clob, charset varchar2 default 'UTF8') as
     v_dest_offset integer := 1;
     v_src_offset integer := 1;
     v_lang_context integer := 0;
@@ -738,7 +738,7 @@ create or replace package body pljson_ext as
       amount => dbms_lob.LOBMAXSIZE,
       dest_offset => v_dest_offset,
       src_offset => v_src_offset,
-      blob_csid => nls_charset_id('UTF8'),
+      blob_csid => nls_charset_id(charset),
       lang_context => v_lang_context,
       warning => v_warning);
   end;

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -725,5 +725,23 @@ create or replace package body pljson_ext as
     
   end decode;
   
+  procedure blob2clob(b blob, c out clob) as
+    v_dest_offset integer := 1;
+    v_src_offset integer := 1;
+    v_lang_context integer := 0;
+    v_warning integer := 0;
+  begin
+    dbms_lob.createtemporary(c, TRUE);
+    dbms_lob.converttoclob(
+      dest_lob => c,
+      src_blob => b,
+      amount => dbms_lob.LOBMAXSIZE,
+      dest_offset => v_dest_offset,
+      src_offset => v_src_offset,
+      blob_csid => nls_charset_id('UTF8'),
+      lang_context => v_lang_context,
+      warning => v_warning);
+  end;
+  
 end pljson_ext;
 /

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -87,6 +87,15 @@ create or replace type pljson_list force under pljson_element (
   constructor function pljson_list(str clob) return self as result,
   
   /**
+   * <p>Create an instance from a given JSON array representation stored in
+   * a <code>BLOB</code>.</p>
+   *
+   * @param str The <code>BLOB</code> to parse.
+   * @return An instance of <code>pljson_list</code>.
+   */
+  constructor function pljson_list(str blob) return self as result,
+  
+  /**
    * <p>Create an instance from a given instance of <code>pljson_value</code>
    * that represents an array.</p>
    *

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -91,9 +91,10 @@ create or replace type pljson_list force under pljson_element (
    * a <code>BLOB</code>.</p>
    *
    * @param str The <code>BLOB</code> to parse.
+   * @param charset The character set of the BLOB data (defaults to UTF-8).
    * @return An instance of <code>pljson_list</code>.
    */
-  constructor function pljson_list(str blob) return self as result,
+  constructor function pljson_list(str blob, charset varchar2 default 'UTF8') return self as result,
   
   /**
    * <p>Create an instance from a given instance of <code>pljson_value</code>

--- a/src/pljson_list.type.impl.sql
+++ b/src/pljson_list.type.impl.sql
@@ -40,6 +40,15 @@ create or replace type body pljson_list as
     return;
   end;
   
+  constructor function pljson_list(str blob) return self as result as
+    c_str clob;
+  begin
+    pljson_ext.blob2clob(str, c_str);
+    self := pljson_parser.parse_list(c_str);
+    dbms_lob.freetemporary(c_str);
+    return;
+  end;
+  
   constructor function pljson_list(elem pljson_value) return self as result as
   begin
     self := treat(elem.object_or_array as pljson_list);

--- a/src/pljson_list.type.impl.sql
+++ b/src/pljson_list.type.impl.sql
@@ -40,10 +40,10 @@ create or replace type body pljson_list as
     return;
   end;
   
-  constructor function pljson_list(str blob) return self as result as
+  constructor function pljson_list(str blob, charset varchar2 default 'UTF8') return self as result as
     c_str clob;
   begin
-    pljson_ext.blob2clob(str, c_str);
+    pljson_ext.blob2clob(str, c_str, charset);
     self := pljson_parser.parse_list(c_str);
     dbms_lob.freetemporary(c_str);
     return;

--- a/testsuite/pljson_unicode.test.sql
+++ b/testsuite/pljson_unicode.test.sql
@@ -196,6 +196,22 @@ begin
     pljson_ut.assertTrue(lengthb(json_var) = 32222, 'lengthb(json_var) = 32222');
   end;
   
+  pljson_ut.testcase('Creation of JSON from BLOB');
+  declare
+    json_char varchar2(4000) := '{"'||text_2_byte||'":"'||text_2_byte||'"}';
+    json_raw varchar2(4000) := utl_i18n.string_to_raw(json_char,'AL32UTF8');
+    b blob;
+  begin
+    dbms_lob.createtemporary(b, true);
+    dbms_lob.writeappend(b, utl_raw.length(json_raw), json_raw);
+    test_json := pljson(b);
+    dbms_lob.freetemporary(b);
+    
+    --dbms_output.put_line(test_json.to_char(false));
+    
+    pljson_ut.assertTrue(json_char = test_json.to_char(false), 'json_char = test_json.to_char()');    
+  end;
+
   t_stop := SYSTIMESTAMP;
   t_sec := time_diff(t_stop, t_start);
   dbms_output.put_line('total sec = ' || to_char(t_sec));

--- a/testsuite/pljson_unicode.test.sql
+++ b/testsuite/pljson_unicode.test.sql
@@ -209,7 +209,7 @@ begin
     
     --dbms_output.put_line(test_json.to_char(false));
     
-    pljson_ut.assertTrue(json_char = test_json.to_char(false), 'json_char = test_json.to_char()');    
+    pljson_ut.assertTrue(json_char = test_json.to_char(false), 'json_char = test_json.to_char(false)');    
   end;
 
   t_stop := SYSTIMESTAMP;


### PR DESCRIPTION
~~WIP, since I cannot test it on this machine.~~ If you're not OK with the change in general, please let me know.

The rationale behind this change is [this](https://docs.oracle.com/cd/E56351_01/doc.30/e87809/developing-REST-applications.htm#GUID-32DC17E1-B78A-41D1-9805-3619D3A21653): ORDS passes the HTTP body as a BLOB. Being able to just `pljson()` it in the handler function is very convenient.