### PR TITLE
fixed bug that prevented correct parsing of numbers with "."

### DIFF
--- a/src/pljson_parser.impl.sql
+++ b/src/pljson_parser.impl.sql
@@ -22,12 +22,15 @@ create or replace package body pljson_parser as
   */
 
   decimalpoint varchar2(1 char) := '.';
-
-  procedure updateDecimalPoint as
+  
+  procedure update_decimalpoint as
   begin
-    SELECT substr(VALUE,1,1) into decimalpoint FROM NLS_SESSION_PARAMETERS WHERE PARAMETER = 'NLS_NUMERIC_CHARACTERS';
-  end updateDecimalPoint;
-
+    select substr(value, 1, 1)
+    into decimalpoint
+    from nls_session_parameters
+    where parameter = 'NLS_NUMERIC_CHARACTERS';
+  end update_decimalpoint;
+  
   /* type json_src is record (len number, offset number, src varchar2(32767), s_clob clob); */
   /* assertions
     offset: contains 0-base offset of buffer,
@@ -660,7 +663,7 @@ create or replace package body pljson_parser as
     indx pls_integer := 1;
     jsrc json_src;
   begin
-    updateDecimalPoint();
+    update_decimalpoint();
     jsrc := prepareVarchar2(str);
     tokens := lexer(jsrc);
     if(tokens(indx).type_name = '{') then
@@ -682,7 +685,7 @@ create or replace package body pljson_parser as
     indx pls_integer := 1;
     jsrc json_src;
   begin
-    updateDecimalPoint();
+    update_decimalpoint();
     jsrc := prepareVarchar2(str);
     tokens := lexer(jsrc);
     if(tokens(indx).type_name = '[') then
@@ -704,7 +707,7 @@ create or replace package body pljson_parser as
     indx pls_integer := 1;
     jsrc json_src;
   begin
-    updateDecimalPoint();
+    update_decimalpoint();
     jsrc := prepareClob(str);
     tokens := lexer(jsrc);
     if(tokens(indx).type_name = '[') then
@@ -726,7 +729,7 @@ create or replace package body pljson_parser as
     indx pls_integer := 1;
     jsrc json_src;
   begin
-    updateDecimalPoint();
+    update_decimalpoint();
     --dbms_output.put_line('Using clob');
     jsrc := prepareClob(str);
     tokens := lexer(jsrc);
@@ -750,7 +753,7 @@ create or replace package body pljson_parser as
     indx pls_integer := 1;
     jsrc json_src;
   begin
-    updateDecimalPoint();
+    update_decimalpoint();
     jsrc := prepareVarchar2(str);
     tokens := lexer(jsrc);
     tokens(tokens.count+1).type_name := ']';
@@ -768,6 +771,7 @@ create or replace package body pljson_parser as
     indx pls_integer := 1;
     jsrc json_src;
   begin
+    update_decimalpoint();
     jsrc := prepareClob(str);
     tokens := lexer(jsrc);
     tokens(tokens.count+1).type_name := ']';
@@ -813,7 +817,7 @@ create or replace package body pljson_parser as
 
   function get_version return varchar2 as
   begin
-    return 'PL/JSON v2.0.0';
+    return 'PL/JSON 2.1.1';
   end get_version;
 
 end pljson_parser;

--- a/src/pljson_value.type.decl.sql
+++ b/src/pljson_value.type.decl.sql
@@ -1,5 +1,5 @@
 create or replace type pljson_value force as object (
-  
+
   /*
   Copyright (c) 2010 Jonas Krogsboell
 
@@ -21,7 +21,7 @@ create or replace type pljson_value force as object (
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
   */
-  
+
   /**
    * <p>Underlying type for all of <em>PL/JSON</em>. Each <code>pljson</code>
    * or <code>pljson_list</code> object is composed of
@@ -33,7 +33,7 @@ create or replace type pljson_value force as object (
    *
    * @headcom
    */
-  
+
   /**
    * <p>Internal property that indicates the JSON type represented:<p>
    * <ol>
@@ -60,13 +60,13 @@ create or replace type pljson_value force as object (
   object_or_array pljson_element, /* object or array in here */
   /** Private variable for internal processing. */
   extended_str clob,
-  
+
   /* mapping */
   /** Private variable for internal processing. */
   mapname varchar2(4000),
   /** Private variable for internal processing. */
   mapindx number(32),
-  
+
   constructor function pljson_value(elem pljson_element) return self as result,
   constructor function pljson_value(str varchar2, esc boolean default true) return self as result,
   constructor function pljson_value(str clob, esc boolean default true) return self as result,
@@ -75,9 +75,9 @@ create or replace type pljson_value force as object (
   constructor function pljson_value(num_double binary_double) return self as result,
   constructor function pljson_value(b boolean) return self as result,
   constructor function pljson_value return self as result,
-  
+
   member function get_element return pljson_element,
-  
+
   /**
    * <p>Create an empty <code>pljson_value</code>.</p>
    *
@@ -93,7 +93,7 @@ create or replace type pljson_value force as object (
    * @return An instance of <code>pljson_value</code>.
    */
   static function makenull return pljson_value,
-  
+
   /**
    * <p>Retrieve the name of the type represented by the <code>pljson_value</code>.</p>
    * <p>Possible return values:</p>
@@ -109,7 +109,7 @@ create or replace type pljson_value force as object (
    * @return The name of the type represented.
    */
   member function get_type return varchar2,
-  
+
   /**
    * <p>Retrieve the value as a string (<code>varchar2</code>).</p>
    *
@@ -118,21 +118,21 @@ create or replace type pljson_value force as object (
    * @return An instance of <code>varchar2</code> or <code>null</code> value is not a string.
    */
   member function get_string(max_byte_size number default null, max_char_size number default null) return varchar2,
-  
+
   /**
    * <p>Retrieve the value as a string represented by a <code>CLOB</code>.</p>
    *
    * @param buf The <code>CLOB</code> in which to store the string.
    */
   member procedure get_string(self in pljson_value, buf in out nocopy clob),
-  
+
   /**
    * <p>Retrieve the value as a <code>number</code>.</p>
    *
    * @return An instance of <code>number</code> or <code>null</code> if the value isn't a number.
    */
   member function get_number return number,
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers */
   /**
    * <p>Retrieve the value as a <code>binary_double</code>.</p>
@@ -140,14 +140,14 @@ create or replace type pljson_value force as object (
    * @return An instance of <code>binary_double</code> or <code>null</code> if the value isn't a number.
    */
   member function get_double return binary_double,
-  
+
   /**
    * <p>Retrieve the value as a <code>boolean</code>.</p>
    *
    * @return An instance of <code>boolean</code> or <code>null</code> if the value isn't a boolean.
    */
   member function get_bool return boolean,
-  
+
   /**
    * <p>Retrieve the value as a string <code>'null'<code>.</p>
    *
@@ -155,49 +155,49 @@ create or replace type pljson_value force as object (
    * an actual <code>null</code> if the value isn't a JSON "null".
    */
   member function get_null return varchar2,
-  
+
   /**
    * <p>Determine if the value represents an "object" type.</p>
    *
    * @return <code>true</code> if the value is an object, <code>false</code> otherwise.
    */
   member function is_object return boolean,
-  
+
   /**
    * <p>Determine if the value represents an "array" type.</p>
    *
    * @return <code>true</code> if the value is an array, <code>false</code> otherwise.
    */
   member function is_array return boolean,
-  
+
   /**
    * <p>Determine if the value represents a "string" type.</p>
    *
    * @return <code>true</code> if the value is a string, <code>false</code> otherwise.
    */
   member function is_string return boolean,
-  
+
   /**
    * <p>Determine if the value represents a "number" type.</p>
    *
    * @return <code>true</code> if the value is a number, <code>false</code> otherwise.
    */
   member function is_number return boolean,
-  
+
   /**
    * <p>Determine if the value represents a "boolean" type.</p>
    *
    * @return <code>true</code> if the value is a boolean, <code>false</code> otherwise.
    */
   member function is_bool return boolean,
-  
+
   /**
    * <p>Determine if the value represents a "null" type.</p>
    *
    * @return <code>true</code> if the value is a null, <code>false</code> otherwise.
    */
   member function is_null return boolean,
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers, is_number is still true, extra info */
   /* return true if 'number' is representable by number */
   /** Private method for internal processing. */
@@ -205,7 +205,7 @@ create or replace type pljson_value force as object (
   /* return true if 'number' is representable by binary_double */
   /** Private method for internal processing. */
   member function is_number_repr_double return boolean,
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers */
   -- set value for number from string representation; to replace to_number in pljson_parser
   -- can automatically decide and use binary_double if needed
@@ -227,8 +227,11 @@ create or replace type pljson_value force as object (
    *
    * @param str A <code>varchar2</code> to parse into a number.
    */
+  -- this procedure is meant to be used internally only
+  -- procedure does not work correctly if called standalone in locales that
+  -- use a character other than "." for decimal point
   member procedure parse_number(str varchar2),
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
   /**
    * <p>Return a <code>varchar2</code> representation of a <code>number</code>
@@ -236,8 +239,9 @@ create or replace type pljson_value force as object (
    *
    * @return A <code>varchar2</code> up to 4000 characters.
    */
+  -- this procedure is meant to be used internally only
   member function number_toString return varchar2,
-  
+
   /* Output methods */
   member function to_char(spaces boolean default true, chars_per_line number default 0) return varchar2,
   member procedure to_clob(self in pljson_value, buf in out nocopy clob, spaces boolean default false, chars_per_line number default 0, erase_clob boolean default true),

--- a/src/pljson_value.type.impl.sql
+++ b/src/pljson_value.type.impl.sql
@@ -1,5 +1,5 @@
 create or replace type body pljson_value as
-  
+
   constructor function pljson_value(elem pljson_element) return self as result as
   begin
     case
@@ -9,10 +9,10 @@ create or replace type body pljson_value as
     end case;
     self.object_or_array := elem;
     if(self.object_or_array is null) then self.typeval := 6; end if;
-    
+
     return;
   end pljson_value;
-  
+
   constructor function pljson_value(str varchar2, esc boolean default true) return self as result as
   begin
     self.typeval := 3;
@@ -20,7 +20,7 @@ create or replace type body pljson_value as
     self.str := str;
     return;
   end pljson_value;
-  
+
   constructor function pljson_value(str clob, esc boolean default true) return self as result as
     /* E.I.Sarmas (github.com/dsnz)   2016-01-21   limit to 5000 chars */
     amount number := 5000; /* for Unicode text, varchar2 'self.str' not exceed 5000 chars, does not limit size of data */
@@ -36,7 +36,7 @@ create or replace type body pljson_value as
     end if;
     return;
   end pljson_value;
-  
+
   constructor function pljson_value(num number) return self as result as
   begin
     self.typeval := 4;
@@ -53,7 +53,7 @@ create or replace type body pljson_value as
     if(self.num is null) then self.typeval := 6; end if;
     return;
   end pljson_value;
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers; typeval not changed, it is still json number */
   constructor function pljson_value(num_double binary_double) return self as result as
   begin
@@ -69,7 +69,7 @@ create or replace type body pljson_value as
     if(self.num_double is null) then self.typeval := 6; end if;
     return;
   end pljson_value;
-  
+
   constructor function pljson_value(b boolean) return self as result as
   begin
     self.typeval := 5;
@@ -78,13 +78,13 @@ create or replace type body pljson_value as
     if(b is null) then self.typeval := 6; end if;
     return;
   end pljson_value;
-  
+
   constructor function pljson_value return self as result as
   begin
     self.typeval := 6; /* for JSON null */
     return;
   end pljson_value;
-  
+
   member function get_element return pljson_element as
   begin
     if (self.typeval in (1,2)) then
@@ -92,12 +92,12 @@ create or replace type body pljson_value as
     end if;
     return null;
   end get_element;
-  
+
   static function makenull return pljson_value as
   begin
     return pljson_value;
   end makenull;
-  
+
   member function get_type return varchar2 as
   begin
     case self.typeval
@@ -111,7 +111,7 @@ create or replace type body pljson_value as
 
     return 'unknown type';
   end get_type;
-  
+
   member function get_string(max_byte_size number default null, max_char_size number default null) return varchar2 as
   begin
     if(self.typeval = 3) then
@@ -125,7 +125,7 @@ create or replace type body pljson_value as
     end if;
     return null;
   end get_string;
-  
+
   member procedure get_string(self in pljson_value, buf in out nocopy clob) as
   begin
     if(self.typeval = 3) then
@@ -136,7 +136,7 @@ create or replace type body pljson_value as
       end if;
     end if;
   end get_string;
-  
+
   member function get_number return number as
   begin
     if(self.typeval = 4) then
@@ -144,7 +144,7 @@ create or replace type body pljson_value as
     end if;
     return null;
   end get_number;
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers */
   member function get_double return binary_double as
   begin
@@ -153,7 +153,7 @@ create or replace type body pljson_value as
     end if;
     return null;
   end get_double;
-  
+
   member function get_bool return boolean as
   begin
     if(self.typeval = 5) then
@@ -161,7 +161,7 @@ create or replace type body pljson_value as
     end if;
     return null;
   end get_bool;
-  
+
   member function get_null return varchar2 as
   begin
     if(self.typeval = 6) then
@@ -169,14 +169,14 @@ create or replace type body pljson_value as
     end if;
     return null;
   end get_null;
-  
+
   member function is_object return boolean as begin return self.typeval = 1; end;
   member function is_array return boolean as begin return self.typeval = 2; end;
   member function is_string return boolean as begin return self.typeval = 3; end;
   member function is_number return boolean as begin return self.typeval = 4; end;
   member function is_bool return boolean as begin return self.typeval = 5; end;
   member function is_null return boolean as begin return self.typeval = 6; end;
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers, is_number is still true, extra check */
   /* return true if 'number' is representable by number */
   member function is_number_repr_number return boolean is
@@ -186,7 +186,7 @@ create or replace type body pljson_value as
     end if;
     return (num_repr_number_p = 't');
   end;
-  
+
   /* return true if 'number' is representable by binary_double */
   member function is_number_repr_double return boolean is
   begin
@@ -195,13 +195,23 @@ create or replace type body pljson_value as
     end if;
     return (num_repr_double_p = 't');
   end;
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers */
   -- set value for number from string representation; to replace to_number in pljson_parser
   -- can automatically decide and use binary_double if needed (set repr variables)
   -- underflows and overflows count as representable if happen on both type representations
   -- less confusing than new constructor with dummy argument for overloading
   -- centralized parse_number to use everywhere else and replace code in pljson_parser
+  --
+  -- WARNING:
+  --
+  -- procedure does not work correctly if called standalone in locales that
+  -- use a character other than "." for decimal point
+  --
+  -- parse_number() is intended to be used inside pljson_parser which
+  -- uses session NLS_PARAMETERS to get decimal point and
+  -- changes "." to this decimal point before calling parse_number()
+  --
   member procedure parse_number(str varchar2) is
   begin
     if self.typeval != 4 then
@@ -218,7 +228,7 @@ create or replace type body pljson_value as
       self.num_repr_double_p := 'f';
     end if;
   end parse_number;
-  
+
   /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
   -- centralized toString to use everywhere else and replace code in pljson_printer
   member function number_toString return varchar2 is
@@ -259,7 +269,7 @@ create or replace type body pljson_value as
       return buf;
     end if;
   end number_toString;
-  
+
   /* Output methods */
   member function to_char(spaces boolean default true, chars_per_line number default 0) return varchar2 as
   begin
@@ -269,7 +279,7 @@ create or replace type body pljson_value as
       return pljson_printer.pretty_print_any(self, spaces, line_length => chars_per_line);
     end if;
   end;
-  
+
   member procedure to_clob(self in pljson_value, buf in out nocopy clob, spaces boolean default false, chars_per_line number default 0, erase_clob boolean default true) as
   begin
     if(spaces is null) then
@@ -278,7 +288,7 @@ create or replace type body pljson_value as
       pljson_printer.pretty_print_any(self, spaces, buf, line_length => chars_per_line, erase_clob => erase_clob);
     end if;
   end;
-  
+
   member procedure print(self in pljson_value, spaces boolean default true, chars_per_line number default 8192, jsonp varchar2 default null) as --32512 is the real maximum in sqldeveloper
     my_clob clob;
   begin
@@ -288,7 +298,7 @@ create or replace type body pljson_value as
     pljson_printer.dbms_output_clob(my_clob, pljson_printer.newline_char, jsonp);
     dbms_lob.freetemporary(my_clob);
   end;
-  
+
   member procedure htp(self in pljson_value, spaces boolean default false, chars_per_line number default 0, jsonp varchar2 default null) as
     my_clob clob;
   begin
@@ -298,7 +308,7 @@ create or replace type body pljson_value as
     pljson_printer.htp_output_clob(my_clob, jsonp);
     dbms_lob.freetemporary(my_clob);
   end;
-  
+
   member function value_of(self in pljson_value, max_byte_size number default null, max_char_size number default null) return varchar2 as
   begin
     case self.typeval
@@ -310,7 +320,7 @@ create or replace type body pljson_value as
     else return null;
     end case;
   end;
-  
+
 end;
 /
 sho err


### PR DESCRIPTION
fixed bug that prevented correct parsing of numbers with "."
as decimal point in locales with different decimal point character

fixed version and changed format to be easier to parse

added documentation warning against use of internal methods of pljson_value()

renamed procedure to depart from camel case as it does not suit PL/SQL