### PR TITLE
changed default installation back to single schema; updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,17 @@ returns
 1.  Download the latest release -- https://github.com/pljson/pljson/releases
 2.  Extract the zip file
 3.  Use `sql*plus`, or something capable of running `sql*plus` scripts, to
-    run the `install.sql` script. (Warning: the default installation needs permission to create public synonyms; if you don't want public access see the note at the end of the install.sql script)
+    run the `install.sql` script.
 4.  To test the implementation, run the `/testsuite/testall.sql` script
+ 
+Warning:
+
+the default installation does not grant access to public
+
+in order to grant access to public you need permission to create public synonyms and
+
+uncomment a line in install.sql script (see note at end of install.sql)
+
 
 **NOTICE:**
 

--- a/install.sql
+++ b/install.sql
@@ -62,9 +62,9 @@ PROMPT ------------------------------------------;
 @@src/addons/pljson_table_impl.type.impl.sql -- dynamic table from json document
 @@testsuite/pljson_ut.package.sql -- pljson unit test mini framework
 
--- comment this and uncomment the block following if you don't want access by public
-@@src/grantsandsynonyms.sql --grants and synonyms for public
-/*
+-- uncomment this and comment the block following if you want access by public
+--@@src/grantsandsynonyms.sql --grants and synonyms for public
+/* */
 -- synonyms for backwards compatibility
 create synonym json_parser for pljson_parser;
 create synonym json_printer for pljson_printer;
@@ -80,4 +80,4 @@ create synonym json_list for pljson_list;
 create synonym json_value_array for pljson_value_array;
 create synonym json_value for pljson_value;
 create synonym json_table for pljson_table;
-*/
+/* */

--- a/src/addons/pljson_table_impl.type.decl.sql
+++ b/src/addons/pljson_table_impl.type.decl.sql
@@ -1,13 +1,12 @@
 set termout off
 create or replace type pljson_varray as table of varchar2(32767);
 /
+create or replace type pljson_narray as table of number;
+/
 
 set termout on
 
 create or replace type pljson_vtab as table of pljson_varray;
-/
-
-create or replace type pljson_narray as table of number;
 /
 
 create synonym pljson_table for pljson_table_impl;

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -1,6 +1,8 @@
 set termout off
 create or replace type pljson_varray as table of varchar2(32767);
 /
+create or replace type pljson_narray as table of number;
+/
 
 set termout on
 create or replace type pljson_list force under pljson_element (

--- a/uninstall.sql
+++ b/uninstall.sql
@@ -63,6 +63,46 @@ declare begin
   begin execute immediate 'drop type pljson_table_impl force'; exception when others then null; end;
   begin execute immediate 'drop package pljson_ut'; exception when others then null; end;
   begin execute immediate 'drop table pljson_testsuite'; exception when others then null; end;
+  
+  begin execute immediate 'drop public synonym pljson_element'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_narray'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_vtab'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_varray'; exception when others then null; end;
+  
+  begin execute immediate 'drop public synonym pljson_parser'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_printer'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_ext'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_dyn'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_ml'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_xml'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_util_pkg'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_helper'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_ac'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_list'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_value_array'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_value'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_table_impl'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_table'; exception when others then null; end;
+  
+  begin execute immediate 'drop public synonym pljson_ut'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_testsuite'; exception when others then null; end;
+  
+  begin execute immediate 'drop public synonym json_parser'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_printer'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_ext'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_dyn'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_ml'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_xml'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_util_pkg'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_helper'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_ac'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_list'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_value_array'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_value'; exception when others then null; end;
+  begin execute immediate 'drop public synonym json_table'; exception when others then null; end;
+  
   begin execute immediate 'drop synonym pljson_table'; exception when others then null; end;
   begin execute immediate 'drop synonym json_parser'; exception when others then null; end;
   begin execute immediate 'drop synonym json_printer'; exception when others then null; end;


### PR DESCRIPTION
does not pollute with public synonyms and grants
unless the user who installs wants so
also if missing 'create public synonym' permission
then will produce error messages which is not user friendly