### PR TITLE
new api calls, minor code rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,25 @@
 General information about JSON is available at http://www.json.org.
 
 ## This is version 2.0
-It is the currently stable PLJSON version
+It is the currently stable PLJSON version.
 
 There is a new version 3.0 (which you can find in branch develop_v3)
-which is mainly a cleaner version but may break up existing code
+which is mainly a cleaner and a bit faster version but may break up existing code.
 
 PLJSON evolved from version 1.0 using sys.anydata and worked with early Oracle releases
 to version 2.0 where sys.anydata was removed and an object oriented design was used but
 the object design wasn't the most appropriate one and mirrored the objects of version 1.0 so that
-there was almost 100% compatibility with version 1.0 code
+there was almost 100% compatibility with version 1.0 code.
 
-both PLJSON version 3.0 and version 2.0 are to be maintained together for quite a long time
+Both PLJSON version 3.0 and version 2.0 are to be maintained together for quite a long time.
 
+## What's new (2018-09-22)
 
+- new api calls that match those of version 3.0
+(mainly get_string(), get_clob(), get_...() by pair_name for json objects and by position for json arrays)
+- minor code rewrite so code is cleaner, conforms better to today's accepted code standards and
+there is as much common code as possible between version 2.0 and version 3.0 (this is a continuing effort)
+- released 2.4.0
 
 ## A demo of things you can do with PL/JSON
 ```
@@ -189,7 +195,7 @@ returns
 | 3	| Middle| 9	| 5 |	extra_5 |
 | 3 |	Middle| 9	| 20|	extra_20|
 
-###### and many other (automatic support for Double numbers or Oracle numbers, base64 encode/decode, XML to json, etc.)
+##### and many other (automatic support for Double numbers or Oracle numbers, base64 encode/decode, XML to json, etc.)
 
 ## Install
 

--- a/install.sql
+++ b/install.sql
@@ -39,14 +39,14 @@ PROMPT -----------------------------------;
 @@src/pljson_value.type.decl.sql
 @@src/pljson_list.type.decl.sql
 @@src/pljson.type.decl.sql
+@@src/pljson_ext.decl.sql --extra helper functions
 @@src/pljson_parser.decl.sql
 @@src/pljson_parser.impl.sql
 @@src/pljson_printer.package.sql
-@@src/pljson_value.type.impl.sql
-@@src/pljson_ext.decl.sql --extra helper functions
 @@src/pljson_ext.impl.sql
-@@src/pljson.type.impl.sql
+@@src/pljson_value.type.impl.sql
 @@src/pljson_list.type.impl.sql
+@@src/pljson.type.impl.sql
 
 @@src/pljson_ac.package.sql --Wrapper to enhance autocompletion
 
@@ -60,6 +60,7 @@ PROMPT ------------------------------------------;
 @@src/addons/pljson_helper.package.sql --Set operations on JSON and JSON_LIST
 @@src/addons/pljson_table_impl.type.decl.sql -- dynamic table from json document
 @@src/addons/pljson_table_impl.type.impl.sql -- dynamic table from json document
+
 @@testsuite/pljson_ut.package.sql -- pljson unit test mini framework
 
 -- uncomment this and comment the block following if you want access by public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pljson",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A PL/SQL object for handling JSON data in Oracle stored procedures and tables.",
   "main": "index.js",
   "directories": {

--- a/src/addons/pljson_dyn.package.sql
+++ b/src/addons/pljson_dyn.package.sql
@@ -40,7 +40,7 @@ create or replace package pljson_dyn authid current_user as
    * begin
    *   res := json_dyn.executeList(
    *            'select :bindme as one, :lala as two from dual where dummy in :arraybind',
-   *            json('{bindme:"4", lala:123, arraybind:[1,2,3,"X"]}')
+   *            json('{bindme:"4", lala:123, arraybind:[1, 2, 3, "X"]}')
    *          );
    *   res.print;
    * end;
@@ -52,6 +52,7 @@ create or replace package pljson_dyn authid current_user as
 */
 end pljson_dyn;
 /
+show err
 
 create or replace package body pljson_dyn as
 /*
@@ -76,27 +77,27 @@ create or replace package body pljson_dyn as
     keylist pljson_list := bindvar.get_keys();
   begin
     for i in 1 .. keylist.count loop
-      if(bindvar.get(i).get_type = 'number') then
-        dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string, bindvar.get(i).get_number);
-      elsif(bindvar.get(i).get_type = 'array') then
+      if (bindvar.get(i).is_number()) then
+        dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string(), bindvar.get(i).get_number());
+      elsif (bindvar.get(i).is_array()) then
         declare
           v_bind dbms_sql.varchar2_table;
           v_arr  pljson_list := pljson_list(bindvar.get(i));
         begin
           for j in 1 .. v_arr.count loop
-            v_bind(j) := v_arr.get(j).value_of;
+            v_bind(j) := v_arr.get(j).value_of();
           end loop;
-          dbms_sql.bind_array(l_cur, ':'||keylist.get(i).get_string, v_bind);
+          dbms_sql.bind_array(l_cur, ':'||keylist.get(i).get_string(), v_bind);
         end;
       else
         if bindvardateformats is not null then
-            if bindvardateformats.exist(keylist.get(i).get_string) then
-                dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string, to_date(bindvar.get(i).value_of(), bindvardateformats.get(keylist.get(i).get_string).get_string() ));
+            if bindvardateformats.exist(keylist.get(i).get_string()) then
+                dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string(), to_date(bindvar.get(i).value_of(), bindvardateformats.get(keylist.get(i).get_string()).get_string() ));
             else
-                dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string, bindvar.get(i).value_of());
+                dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string(), bindvar.get(i).value_of());
             end if;
         else
-            dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string, bindvar.get(i).value_of());
+            dbms_sql.bind_variable(l_cur, ':'||keylist.get(i).get_string(), bindvar.get(i).value_of());
         end if;
       end if;
     end loop;
@@ -119,54 +120,55 @@ create or replace package body pljson_dyn as
     read_varray pljson_varray;
     read_narray pljson_narray;
   begin
-    if(cur_num is not null) then
+    if (cur_num is not null) then
       l_cur := cur_num;
     else
       l_cur := dbms_sql.open_cursor;
       dbms_sql.parse(l_cur, stmt, dbms_sql.native);
-      if(bindvar is not null) then bind_json(l_cur, bindvar, bindvardateformats); end if;
+      if (bindvar is not null) then bind_json(l_cur, bindvar, bindvardateformats); end if;
     end if;
-    /* E.I.Sarmas (github.com/dsnz)   2018-05-01   handling of varray,narray in select */
+    /* E.I.Sarmas (github.com/dsnz)   2018-05-01   handling of varray, narray in select */
     dbms_sql.describe_columns3(l_cur, l_cnt, l_dtbl);
     for i in 1..l_cnt loop
       col_type := l_dtbl(i).col_type;
       --dbms_output.put_line(col_type);
-      if(col_type = 12) then
-        dbms_sql.define_column(l_cur,i,read_date);
-      elsif(col_type = 112) then
-        dbms_sql.define_column(l_cur,i,read_clob);
-      elsif(col_type = 113) then
-        dbms_sql.define_column(l_cur,i,read_blob);
-      elsif(col_type in (1,2,96)) then
-        dbms_sql.define_column(l_cur,i,l_val,4000);
+      if (col_type = 12) then
+        dbms_sql.define_column(l_cur, i, read_date);
+      elsif (col_type = 112) then
+        dbms_sql.define_column(l_cur, i, read_clob);
+      elsif (col_type = 113) then
+        dbms_sql.define_column(l_cur, i, read_blob);
+      elsif (col_type in (1, 2, 96)) then
+        dbms_sql.define_column(l_cur, i, l_val, 4000);
       /* E.I.Sarmas (github.com/dsnz)   2018-05-01   handling of pljson_varray in select */
-      elsif(col_type = 109 and l_dtbl(i).col_type_name = 'PLJSON_VARRAY') then
-        dbms_sql.define_column(l_cur,i,read_varray);
+      elsif (col_type = 109 and l_dtbl(i).col_type_name = 'PLJSON_VARRAY') then
+        dbms_sql.define_column(l_cur, i, read_varray);
       /* E.I.Sarmas (github.com/dsnz)   2018-05-01   handling of pljson_narray in select */
-      elsif(col_type = 109 and l_dtbl(i).col_type_name = 'PLJSON_NARRAY') then
-        dbms_sql.define_column(l_cur,i,read_narray);
+      elsif (col_type = 109 and l_dtbl(i).col_type_name = 'PLJSON_NARRAY') then
+        dbms_sql.define_column(l_cur, i, read_narray);
       /* E.I.Sarmas (github.com/dsnz)   2018-05-01   record unhandled col_type */
       else
         dbms_output.put_line('unhandled col_type =' || col_type);
       end if;
     end loop;
 
-    if(cur_num is null) then l_status := dbms_sql.execute(l_cur); end if;
+    if (cur_num is null) then l_status := dbms_sql.execute(l_cur); end if;
 
     --loop through rows
     while ( dbms_sql.fetch_rows(l_cur) > 0 ) loop
       inner_obj := pljson(); --init for each row
+      inner_obj.check_for_duplicate := 0;
       --loop through columns
       for i in 1..l_cnt loop
         case true
         --handling string types
-        when l_dtbl(i).col_type in (1,96) then -- varchar2
-          dbms_sql.column_value(l_cur,i,l_val);
-          if(l_val is null) then
-            if(null_as_empty_string) then
-              inner_obj.put(l_dtbl(i).col_name, ''); --treatet as emptystring?
+        when l_dtbl(i).col_type in (1, 96) then -- varchar2
+          dbms_sql.column_value(l_cur, i, l_val);
+          if (l_val is null) then
+            if (null_as_empty_string) then
+              inner_obj.put(l_dtbl(i).col_name, ''); --treat as emptystring?
             else
-              inner_obj.put(l_dtbl(i).col_name, pljson_value.makenull); --null
+              inner_obj.put(l_dtbl(i).col_name, pljson_value()); --null
             end if;
           else
             inner_obj.put(l_dtbl(i).col_name, pljson_value(l_val)); --null
@@ -174,46 +176,47 @@ create or replace package body pljson_dyn as
           --dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'varchar2' ||l_dtbl(i).col_type);
         --handling number types
         when l_dtbl(i).col_type = 2 then -- number
-          dbms_sql.column_value(l_cur,i,l_val);
+          dbms_sql.column_value(l_cur, i, l_val);
           conv := l_val;
           inner_obj.put(l_dtbl(i).col_name, conv);
           -- dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'number ' ||l_dtbl(i).col_type);
         when l_dtbl(i).col_type = 12 then -- date
-          if(include_dates) then
-            dbms_sql.column_value(l_cur,i,read_date);
+          if (include_dates) then
+            dbms_sql.column_value(l_cur, i, read_date);
             inner_obj.put(l_dtbl(i).col_name, pljson_ext.to_json_value(read_date));
           end if;
           --dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'date ' ||l_dtbl(i).col_type);
         when l_dtbl(i).col_type = 112 then --clob
-          if(include_clobs) then
-            dbms_sql.column_value(l_cur,i,read_clob);
+          if (include_clobs) then
+            dbms_sql.column_value(l_cur, i, read_clob);
             inner_obj.put(l_dtbl(i).col_name, pljson_value(read_clob));
           end if;
         when l_dtbl(i).col_type = 113 then --blob
-          if(include_blobs) then
-            dbms_sql.column_value(l_cur,i,read_blob);
-            if(dbms_lob.getlength(read_blob) > 0) then
+          if (include_blobs) then
+            dbms_sql.column_value(l_cur, i, read_blob);
+            if (dbms_lob.getlength(read_blob) > 0) then
               inner_obj.put(l_dtbl(i).col_name, pljson_ext.encode(read_blob));
             else
-              inner_obj.put(l_dtbl(i).col_name, pljson_value.makenull);
+              inner_obj.put(l_dtbl(i).col_name, pljson_value());
             end if;
           end if;
         /* E.I.Sarmas (github.com/dsnz)   2018-05-01   handling of pljson_varray in select */
         when l_dtbl(i).col_type = 109 and l_dtbl(i).col_type_name = 'PLJSON_VARRAY' then
           if (include_arrays) then
-            dbms_sql.column_value(l_cur,i,read_varray);
+            dbms_sql.column_value(l_cur, i, read_varray);
             inner_obj.put(l_dtbl(i).col_name, pljson_list(read_varray));
           end if;
         /* E.I.Sarmas (github.com/dsnz)   2018-05-01   handling of pljson_narray in select */
         when l_dtbl(i).col_type = 109 and l_dtbl(i).col_type_name = 'PLJSON_NARRAY' then
           if (include_arrays) then
-            dbms_sql.column_value(l_cur,i,read_narray);
+            dbms_sql.column_value(l_cur, i, read_narray);
             inner_obj.put(l_dtbl(i).col_name, pljson_list(read_narray));
           end if;
           
         else null; --discard other types
         end case;
       end loop;
+      inner_obj.check_for_duplicate := 1;
       outer_list.append(inner_obj.to_json_value);
     end loop;
     dbms_sql.close_cursor(l_cur);
@@ -237,27 +240,27 @@ create or replace package body pljson_dyn as
     read_blob blob;
     col_type number;
   begin
-    if(cur_num is not null) then
+    if (cur_num is not null) then
       l_cur := cur_num;
     else
       l_cur := dbms_sql.open_cursor;
       dbms_sql.parse(l_cur, stmt, dbms_sql.native);
-      if(bindvar is not null) then bind_json(l_cur, bindvar); end if;
+      if (bindvar is not null) then bind_json(l_cur, bindvar); end if;
     end if;
     dbms_sql.describe_columns(l_cur, l_cnt, l_dtbl);
     for i in 1..l_cnt loop
       col_type := l_dtbl(i).col_type;
-      if(col_type = 12) then
-        dbms_sql.define_column(l_cur,i,read_date);
-      elsif(col_type = 112) then
-        dbms_sql.define_column(l_cur,i,read_clob);
-      elsif(col_type = 113) then
-        dbms_sql.define_column(l_cur,i,read_blob);
-      elsif(col_type in (1,2,96)) then
-        dbms_sql.define_column(l_cur,i,l_val,4000);
+      if (col_type = 12) then
+        dbms_sql.define_column(l_cur, i, read_date);
+      elsif (col_type = 112) then
+        dbms_sql.define_column(l_cur, i, read_clob);
+      elsif (col_type = 113) then
+        dbms_sql.define_column(l_cur, i, read_blob);
+      elsif (col_type in (1, 2, 96)) then
+        dbms_sql.define_column(l_cur, i, l_val, 4000);
       end if;
     end loop;
-    if(cur_num is null) then l_status := dbms_sql.execute(l_cur); end if;
+    if (cur_num is null) then l_status := dbms_sql.execute(l_cur); end if;
 
     --build up name_list
     for i in 1..l_cnt loop
@@ -265,9 +268,9 @@ create or replace package body pljson_dyn as
         when 1 then inner_list_names.append(l_dtbl(i).col_name);
         when 96 then inner_list_names.append(l_dtbl(i).col_name);
         when 2 then inner_list_names.append(l_dtbl(i).col_name);
-        when 12 then if(include_dates) then inner_list_names.append(l_dtbl(i).col_name); end if;
-        when 112 then if(include_clobs) then inner_list_names.append(l_dtbl(i).col_name); end if;
-        when 113 then if(include_blobs) then inner_list_names.append(l_dtbl(i).col_name); end if;
+        when 12 then if (include_dates) then inner_list_names.append(l_dtbl(i).col_name); end if;
+        when 112 then if (include_clobs) then inner_list_names.append(l_dtbl(i).col_name); end if;
+        when 113 then if (include_blobs) then inner_list_names.append(l_dtbl(i).col_name); end if;
         else null;
       end case;
     end loop;
@@ -279,13 +282,13 @@ create or replace package body pljson_dyn as
       for i in 1..l_cnt loop
         case true
         --handling string types
-        when l_dtbl(i).col_type in (1,96) then -- varchar2
-          dbms_sql.column_value(l_cur,i,l_val);
-          if(l_val is null) then
-            if(null_as_empty_string) then
-              data_list.append(''); --treatet as emptystring?
+        when l_dtbl(i).col_type in (1, 96) then -- varchar2
+          dbms_sql.column_value(l_cur, i, l_val);
+          if (l_val is null) then
+            if (null_as_empty_string) then
+              data_list.append(''); --treat as emptystring?
             else
-              data_list.append(pljson_value.makenull); --null
+              data_list.append(pljson_value()); --null
             end if;
           else
             data_list.append(pljson_value(l_val)); --null
@@ -293,28 +296,28 @@ create or replace package body pljson_dyn as
           --dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'varchar2' ||l_dtbl(i).col_type);
         --handling number types
         when l_dtbl(i).col_type = 2 then -- number
-          dbms_sql.column_value(l_cur,i,l_val);
+          dbms_sql.column_value(l_cur, i, l_val);
           conv := l_val;
           data_list.append(conv);
           -- dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'number ' ||l_dtbl(i).col_type);
         when l_dtbl(i).col_type = 12 then -- date
-          if(include_dates) then
-            dbms_sql.column_value(l_cur,i,read_date);
+          if (include_dates) then
+            dbms_sql.column_value(l_cur, i, read_date);
             data_list.append(pljson_ext.to_json_value(read_date));
           end if;
           --dbms_output.put_line(l_dtbl(i).col_name||' --> '||l_val||'date ' ||l_dtbl(i).col_type);
         when l_dtbl(i).col_type = 112 then --clob
-          if(include_clobs) then
-            dbms_sql.column_value(l_cur,i,read_clob);
+          if (include_clobs) then
+            dbms_sql.column_value(l_cur, i, read_clob);
             data_list.append(pljson_value(read_clob));
           end if;
         when l_dtbl(i).col_type = 113 then --blob
-          if(include_blobs) then
-            dbms_sql.column_value(l_cur,i,read_blob);
-            if(dbms_lob.getlength(read_blob) > 0) then
+          if (include_blobs) then
+            dbms_sql.column_value(l_cur, i, read_blob);
+            if (dbms_lob.getlength(read_blob) > 0) then
               data_list.append(pljson_ext.encode(read_blob));
             else
-              data_list.append(pljson_value.makenull);
+              data_list.append(pljson_value());
             end if;
           end if;
         else null; --discard other types
@@ -331,3 +334,4 @@ create or replace package body pljson_dyn as
 
 end pljson_dyn;
 /
+show err

--- a/src/addons/pljson_helper.package.sql
+++ b/src/addons/pljson_helper.package.sql
@@ -14,19 +14,19 @@ create or replace package pljson_helper as
   */
   -- Recursive merge
   -- Courtesy of Matt Nolan - edited by Jonas Krogsboell
-  function merge( p_a_json pljson, p_b_json pljson) return pljson;
+  function merge(p_a_json pljson, p_b_json pljson) return pljson;
   
   -- Join two lists
   -- json_helper.join(json_list('[1,2,3]'),json_list('[4,5,6]')) -> [1,2,3,4,5,6]
-  function join( p_a_list pljson_list, p_b_list pljson_list) return pljson_list;
+  function join(p_a_list pljson_list, p_b_list pljson_list) return pljson_list;
   
   -- keep only specific keys in json object
   -- json_helper.keep(json('{a:1,b:2,c:3,d:4,e:5,f:6}'),json_list('["a","f","c"]')) -> {"a":1,"f":6,"c":3}
-  function keep( p_json pljson, p_keys pljson_list) return pljson;
+  function keep(p_json pljson, p_keys pljson_list) return pljson;
   
   -- remove specific keys in json object
   -- json_helper.remove(json('{a:1,b:2,c:3,d:4,e:5,f:6}'),json_list('["a","f","c"]')) -> {"b":2,"d":4,"e":5}
-  function remove( p_json pljson, p_keys pljson_list) return pljson;
+  function remove(p_json pljson, p_keys pljson_list) return pljson;
   
   --equals
   function equals(p_v1 pljson_value, p_v2 pljson_value, exact boolean default true) return boolean;
@@ -65,11 +65,12 @@ create or replace package pljson_helper as
 
 end pljson_helper;
 /
+show err
 
 create or replace package body pljson_helper as
   
   --recursive merge
-  function merge( p_a_json pljson, p_b_json pljson) return pljson as
+  function merge(p_a_json pljson, p_b_json pljson) return pljson as
     l_json    pljson;
     l_jv      pljson_value;
     l_indx    number;
@@ -85,10 +86,10 @@ create or replace package body pljson_helper as
     loop
       exit when l_indx is null;
       l_jv   := p_b_json.json_data(l_indx);
-      if(l_jv.is_object) then
+      if (l_jv.is_object) then
         --recursive
         l_recursive := l_json.get(l_jv.mapname);
-        if(l_recursive is not null and l_recursive.is_object) then
+        if (l_recursive is not null and l_recursive.is_object) then
           l_json.put(l_jv.mapname, merge(pljson(l_recursive), pljson(l_jv)));
         else
           l_json.put(l_jv.mapname, l_jv);
@@ -106,7 +107,7 @@ create or replace package body pljson_helper as
   end merge;
   
   -- join two lists
-  function join( p_a_list pljson_list, p_b_list pljson_list) return pljson_list as
+  function join(p_a_list pljson_list, p_b_list pljson_list) return pljson_list as
     l_json_list pljson_list := p_a_list;
   begin
     for indx in 1 .. p_b_list.count loop
@@ -118,13 +119,13 @@ create or replace package body pljson_helper as
   end join;
   
   -- keep keys.
-  function keep( p_json pljson, p_keys pljson_list) return pljson as
+  function keep(p_json pljson, p_keys pljson_list) return pljson as
     l_json pljson := pljson();
     mapname varchar2(4000);
   begin
     for i in 1 .. p_keys.count loop
-      mapname := p_keys.get(i).get_string;
-      if(p_json.exist(mapname)) then
+      mapname := p_keys.get(i).get_string();
+      if (p_json.exist(mapname)) then
         l_json.put(mapname, p_json.get(mapname));
       end if;
     end loop;
@@ -133,11 +134,11 @@ create or replace package body pljson_helper as
   end keep;
   
   -- drop keys.
-  function remove( p_json pljson, p_keys pljson_list) return pljson as
+  function remove(p_json pljson, p_keys pljson_list) return pljson as
     l_json pljson := p_json;
   begin
     for i in 1 .. p_keys.count loop
-      l_json.remove(p_keys.get(i).get_string);
+      l_json.remove(p_keys.get(i).get_string());
     end loop;
     
     return l_json;
@@ -147,100 +148,105 @@ create or replace package body pljson_helper as
   
   function equals(p_v1 pljson_value, p_v2 number) return boolean as
   begin
-    if(p_v2 is null) then
+    if (p_v2 is null) then
       return p_v1.is_null;
     end if;
     
-    if(not p_v1.is_number) then
+    if (not p_v1.is_number) then
       return false;
     end if;
     
-    return p_v2 = p_v1.get_number;
+    return p_v2 = p_v1.get_number();
   end;
   
   /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
   function equals(p_v1 pljson_value, p_v2 binary_double) return boolean as
   begin
-    if(p_v2 is null) then
+    if (p_v2 is null) then
       return p_v1.is_null;
     end if;
 
-    if(not p_v1.is_number) then
+    if (not p_v1.is_number) then
       return false;
     end if;
 
-    return p_v2 = p_v1.get_double;
+    return p_v2 = p_v1.get_double();
   end;
   
   function equals(p_v1 pljson_value, p_v2 boolean) return boolean as
   begin
-    if(p_v2 is null) then
+    if (p_v2 is null) then
       return p_v1.is_null;
     end if;
     
-    if(not p_v1.is_bool) then
+    if (not p_v1.is_bool) then
       return false;
     end if;
     
-    return p_v2 = p_v1.get_bool;
+    return p_v2 = p_v1.get_bool();
   end;
   
   function equals(p_v1 pljson_value, p_v2 varchar2) return boolean as
   begin
-    if(p_v2 is null) then
-      return (p_v1.is_null or p_v1.get_string is null);
+    if (p_v2 is null) then
+      return (p_v1.is_null or p_v1.get_string() is null);
     end if;
     
-    if(not p_v1.is_string) then
+    if (not p_v1.is_string) then
       return false;
     end if;
     
-    return p_v2 = p_v1.get_string;
+    return p_v2 = p_v1.get_string();
   end;
   
   function equals(p_v1 pljson_value, p_v2 clob) return boolean as
     my_clob clob;
     res boolean;
   begin
-    if(p_v2 is null) then
+    if (p_v2 is null) then
       return p_v1.is_null;
     end if;
     
-    if(not p_v1.is_string) then
+    if (not p_v1.is_string) then
       return false;
     end if;
     
+    /*
     my_clob := empty_clob();
     dbms_lob.createtemporary(my_clob, true);
     p_v1.get_string(my_clob);
-    
+    */
+    my_clob := p_v1.get_clob();
     res := dbms_lob.compare(p_v2, my_clob) = 0;
-    dbms_lob.freetemporary(my_clob);
+    /*dbms_lob.freetemporary(my_clob);*/
     return res;
   end;
   
   function equals(p_v1 pljson_value, p_v2 pljson_value, exact boolean) return boolean as
   begin
-    if(p_v2 is null or p_v2.is_null) then
+    if (p_v2 is null or p_v2.is_null) then
       return (p_v1 is null or p_v1.is_null);
     end if;
     
-    if(p_v2.is_number) then return equals(p_v1, p_v2.get_number); end if;
-    if(p_v2.is_bool) then return equals(p_v1, p_v2.get_bool); end if;
-    if(p_v2.is_object) then return equals(p_v1, pljson(p_v2), exact); end if;
-    if(p_v2.is_array) then return equals(p_v1, pljson_list(p_v2), exact); end if;
-    if(p_v2.is_string) then
-      if(p_v2.extended_str is null) then
+    if (p_v2.is_number) then return equals(p_v1, p_v2.get_number); end if;
+    if (p_v2.is_bool) then return equals(p_v1, p_v2.get_bool); end if;
+    if (p_v2.is_object) then return equals(p_v1, pljson(p_v2), exact); end if;
+    if (p_v2.is_array) then return equals(p_v1, pljson_list(p_v2), exact); end if;
+    if (p_v2.is_string) then
+      if (p_v2.extended_str is null) then
         return equals(p_v1, p_v2.get_string);
       else
         declare
           my_clob clob; res boolean;
         begin
+          /*
           my_clob := empty_clob();
           dbms_lob.createtemporary(my_clob, true);
           p_v2.get_string(my_clob);
+          */
+          my_clob := p_v2.get_clob();
           res := equals(p_v1, my_clob);
-          dbms_lob.freetemporary(my_clob);
+          /*dbms_lob.freetemporary(my_clob);*/
           return res;
         end;
       end if;
@@ -257,29 +263,29 @@ create or replace package body pljson_helper as
 --  p_v2.print(false);
 --  dbms_output.put_line('labc1'||case when exact then 'X' else 'U' end);
     
-    if(p_v2 is null) then
+    if (p_v2 is null) then
       return p_v1.is_null;
     end if;
     
-    if(not p_v1.is_array) then
+    if (not p_v1.is_array) then
       return false;
     end if;
     
 --  dbms_output.put_line('labc2'||case when exact then 'X' else 'U' end);
     
     cmp := pljson_list(p_v1);
-    if(cmp.count != p_v2.count and exact) then return false; end if;
+    if (cmp.count != p_v2.count and exact) then return false; end if;
     
 --  dbms_output.put_line('labc3'||case when exact then 'X' else 'U' end);
     
-    if(exact) then
+    if (exact) then
       for i in 1 .. cmp.count loop
         res := equals(cmp.get(i), p_v2.get(i), exact);
-        if(not res) then return res; end if;
+        if (not res) then return res; end if;
       end loop;
     else
 --  dbms_output.put_line('labc4'||case when exact then 'X' else 'U' end);
-      if(p_v2.count > cmp.count) then return false; end if;
+      if (p_v2.count > cmp.count) then return false; end if;
 --  dbms_output.put_line('labc5'||case when exact then 'X' else 'U' end);
       
       --match sublist here!
@@ -288,7 +294,7 @@ create or replace package body pljson_helper as
         
         for i in 1 .. p_v2.count loop
           res := equals(cmp.get(x+i), p_v2.get(i), exact);
-          if(not res) then
+          if (not res) then
             goto next_index;
           end if;
         end loop;
@@ -315,11 +321,11 @@ create or replace package body pljson_helper as
 --  p_v2.print(false);
 --  dbms_output.put_line('abc1');
     
-    if(p_v2 is null) then
+    if (p_v2 is null) then
       return p_v1.is_null;
     end if;
     
-    if(not p_v1.is_object) then
+    if (not p_v1.is_object) then
       return false;
     end if;
     
@@ -327,18 +333,18 @@ create or replace package body pljson_helper as
     
 --  dbms_output.put_line('abc2');
     
-    if(cmp.count != p_v2.count and exact) then return false; end if;
+    if (cmp.count != p_v2.count and exact) then return false; end if;
     
 --  dbms_output.put_line('abc3');
     declare
-      k1 pljson_list := p_v2.get_keys;
+      k1 pljson_list := p_v2.get_keys();
       key_index number;
     begin
       for i in 1 .. k1.count loop
-        key_index := cmp.index_of(k1.get(i).get_string);
-        if(key_index = -1) then return false; end if;
-        if(exact) then
-          if(not equals(p_v2.get(i), cmp.get(key_index), true)) then return false; end if;
+        key_index := cmp.index_of(k1.get(i).get_string());
+        if (key_index = -1) then return false; end if;
+        if (exact) then
+          if (not equals(p_v2.get(i), cmp.get(key_index), true)) then return false; end if;
         else
           --non exact
           declare
@@ -349,12 +355,12 @@ create or replace package body pljson_helper as
 --            v1.print(false);
 --            v2.print(false);
             
-            if(v1.is_object and v2.is_object) then
-              if(not equals(v1, v2, false)) then return false; end if;
-            elsif(v1.is_array and v2.is_array) then
-              if(not equals(v1, v2, false)) then return false; end if;
+            if (v1.is_object and v2.is_object) then
+              if (not equals(v1, v2, false)) then return false; end if;
+            elsif (v1.is_array and v2.is_array) then
+              if (not equals(v1, v2, false)) then return false; end if;
             else
-              if(not equals(v1, v2, true)) then return false; end if;
+              if (not equals(v1, v2, true)) then return false; end if;
             end if;
           end;
         
@@ -381,22 +387,22 @@ create or replace package body pljson_helper as
   function contains(p_v1 pljson, p_v2 pljson_value, exact boolean) return boolean as
     v_values pljson_list;
   begin
-    if(equals(p_v1.to_json_value, p_v2, exact)) then return true; end if;
+    if (equals(p_v1.to_json_value, p_v2, exact)) then return true; end if;
     
-    v_values := p_v1.get_values;
+    v_values := p_v1.get_values();
     
     for i in 1 .. v_values.count loop
       declare
         v_val pljson_value := v_values.get(i);
       begin
-        if(v_val.is_object) then
-          if(contains(pljson(v_val), p_v2, exact)) then return true; end if;
+        if (v_val.is_object) then
+          if (contains(pljson(v_val), p_v2, exact)) then return true; end if;
         end if;
-        if(v_val.is_array) then
-          if(contains(pljson_list(v_val), p_v2, exact)) then return true; end if;
+        if (v_val.is_array) then
+          if (contains(pljson_list(v_val), p_v2, exact)) then return true; end if;
         end if;
         
-        if(equals(v_val, p_v2, exact)) then return true; end if;
+        if (equals(v_val, p_v2, exact)) then return true; end if;
       end;
     
     end loop;
@@ -406,20 +412,20 @@ create or replace package body pljson_helper as
   
   function contains(p_v1 pljson_list, p_v2 pljson_value, exact boolean) return boolean as
   begin
-    if(equals(p_v1.to_json_value, p_v2, exact)) then return true; end if;
+    if (equals(p_v1.to_json_value, p_v2, exact)) then return true; end if;
     
     for i in 1 .. p_v1.count loop
       declare
         v_val pljson_value := p_v1.get(i);
       begin
-        if(v_val.is_object) then
-          if(contains(pljson(v_val), p_v2, exact)) then return true; end if;
+        if (v_val.is_object) then
+          if (contains(pljson(v_val), p_v2, exact)) then return true; end if;
         end if;
-        if(v_val.is_array) then
-          if(contains(pljson_list(v_val), p_v2, exact)) then return true; end if;
+        if (v_val.is_array) then
+          if (contains(pljson_list(v_val), p_v2, exact)) then return true; end if;
         end if;
         
-        if(equals(v_val, p_v2, exact)) then return true; end if;
+        if (equals(v_val, p_v2, exact)) then return true; end if;
       end;
     
     end loop;
@@ -462,6 +468,7 @@ create or replace package body pljson_helper as
 
 end pljson_helper;
 /
+show err
 
 
 /**
@@ -474,7 +481,7 @@ declare
 
 
 begin
-  if(json_helper.contains(v1, v2)) then
+  if (json_helper.contains(v1, v2)) then
     dbms_output.put_line('************123');
   end if;
   

--- a/src/addons/pljson_ml.package.sql
+++ b/src/addons/pljson_ml.package.sql
@@ -33,6 +33,8 @@ create or replace package pljson_ml as
 
 end pljson_ml;
 /
+show err
+
 create or replace package body pljson_ml as
   function get_jsonml_stylesheet return xmltype;
 
@@ -54,7 +56,7 @@ create or replace package body pljson_ml as
 
   function get_jsonml_stylesheet return xmltype as
   begin
-    if(jsonml_stylesheet is null) then
+    if (jsonml_stylesheet is null) then
     jsonml_stylesheet := xmltype('<?xml version="1.0" encoding="UTF-8"?>
 <!--
 		JsonML.xslt
@@ -303,3 +305,4 @@ create or replace package body pljson_ml as
 
 end pljson_ml;
 /
+show err

--- a/src/addons/pljson_table_impl.type.decl.sql
+++ b/src/addons/pljson_table_impl.type.decl.sql
@@ -5,11 +5,8 @@ create or replace type pljson_narray as table of number;
 /
 
 set termout on
-
 create or replace type pljson_vtab as table of pljson_varray;
 /
-
-create synonym pljson_table for pljson_table_impl;
 
 create or replace type pljson_table_impl as object (
   
@@ -158,3 +155,6 @@ create or replace type pljson_table_impl as object (
   pipelined using pljson_table_impl
 );
 /
+show err
+
+create synonym pljson_table for pljson_table_impl;

--- a/src/addons/pljson_table_impl.type.impl.sql
+++ b/src/addons/pljson_table_impl.type.impl.sql
@@ -145,7 +145,7 @@ create or replace type body pljson_table_impl as
     --dbms_output.put_line('json_str='||json_str);
     -- json_obj := pljson(json_str);
     root_val := pljson_parser.parse_any(json_str);
-    --dbms_output.put_line('parsed: ' || root_val.get_type);
+    --dbms_output.put_line('parsed: ' || root_val.get_type());
     if root_val.typeval = 2 then
       root_list := pljson_list(root_val);
       root_array_size := root_list.count;
@@ -531,3 +531,4 @@ create or replace type body pljson_table_impl as
   end;
 end;
 /
+show err

--- a/src/addons/pljson_util_pkg.package.sql
+++ b/src/addons/pljson_util_pkg.package.sql
@@ -30,6 +30,7 @@ create or replace package pljson_util_pkg authid current_user as
 
 end pljson_util_pkg;
 /
+show err
 
 create or replace package body pljson_util_pkg as
   scanner_exception exception;
@@ -53,8 +54,7 @@ create or replace package body pljson_util_pkg as
   g_json_null_object             constant varchar2(20) := '{ }';
 
 
-function get_xml_to_json_stylesheet return varchar2
-as
+function get_xml_to_json_stylesheet return varchar2 as
 begin
 
   /*
@@ -354,3 +354,4 @@ end sql_to_json;
 
 end pljson_util_pkg;
 /
+show err

--- a/src/addons/pljson_xml.package.sql
+++ b/src/addons/pljson_xml.package.sql
@@ -25,7 +25,7 @@ create or replace package pljson_xml as
 
   /*
   declare
-    obj json := json('{a:1,b:[2,3,4],c:true}');
+    obj json := json('{a:1, b:[2, 3, 4], c:true}');
     x xmltype;
   begin
     obj.print;
@@ -38,6 +38,7 @@ create or replace package pljson_xml as
 
 end pljson_xml;
 /
+show err
 
 create or replace package body pljson_xml as
 
@@ -61,7 +62,7 @@ create or replace package body pljson_xml as
 /* Clob methods from printer */
   procedure add_to_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2, str varchar2) as
   begin
-    if(length(str) > 32767 - length(buf_str)) then
+    if (length(str) > 32767 - length(buf_str)) then
       dbms_lob.append(buf_lob, buf_str);
       buf_str := str;
     else
@@ -89,28 +90,28 @@ create or replace package body pljson_xml as
       v_keys := v_obj.get_keys();
       for i in 1 .. v_keys.count loop
         v_value := v_obj.get(i);
-        key_str := v_keys.get(i).str;
+        key_str := v_keys.get(i).get_string();
         
-        if(key_str = 'content') then
-          if(v_value.is_array()) then
+        if (key_str = 'content') then
+          if (v_value.is_array()) then
             declare
               v_l pljson_list := pljson_list(v_value);
             begin
               for j in 1 .. v_l.count loop
-                if(j > 1) then add_to_clob(xmlstr, xmlbuf, chr(13)||chr(10)); end if;
+                if (j > 1) then add_to_clob(xmlstr, xmlbuf, chr(13)||chr(10)); end if;
                 add_to_clob(xmlstr, xmlbuf, escapeStr(v_l.get(j).to_char()));
               end loop;
             end;
           else
             add_to_clob(xmlstr, xmlbuf, escapeStr(v_value.to_char()));
           end if;
-        elsif(v_value.is_array()) then
+        elsif (v_value.is_array()) then
           declare
             v_l pljson_list := pljson_list(v_value);
           begin
             for j in 1 .. v_l.count loop
               v_value := v_l.get(j);
-              if(v_value.is_array()) then
+              if (v_value.is_array()) then
                 add_to_clob(xmlstr, xmlbuf, '<' || key_str || '>');
                 add_to_clob(xmlstr, xmlbuf, escapeStr(v_value.to_char()));
                 add_to_clob(xmlstr, xmlbuf, '</' || key_str || '>');
@@ -119,7 +120,7 @@ create or replace package body pljson_xml as
               end if;
             end loop;
           end;
-        elsif(v_value.is_null() or (v_value.is_string and v_value.get_string = '')) then
+        elsif (v_value.is_null() or (v_value.is_string() and v_value.get_string() = '')) then
           add_to_clob(xmlstr, xmlbuf, '<' || key_str || '/>');
         else
           toString(v_value, key_str, xmlstr, xmlbuf);
@@ -145,7 +146,7 @@ create or replace package body pljson_xml as
   begin
     dbms_lob.createtemporary(xmlstr, true);
     
-    toString(obj.to_json_value(), tagname, xmlstr, xmlbuf);
+    toString(obj.to_json_value, tagname, xmlstr, xmlbuf);
     
     flush_clob(xmlstr, xmlbuf);
     returnValue := xmltype('<?xml version="1.0"?>'||xmlstr);
@@ -155,3 +156,4 @@ create or replace package body pljson_xml as
 
 end pljson_xml;
 /
+show err

--- a/src/pljson_ext.decl.sql
+++ b/src/pljson_ext.decl.sql
@@ -98,6 +98,6 @@ create or replace package pljson_ext as
     implemented as a procedure to force you to declare the CLOB so you can free it later
   */
   procedure blob2clob(b blob, c out clob, charset varchar2 default 'UTF8');
-
 end pljson_ext;
 /
+show err

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -36,21 +36,24 @@ create or replace package body pljson_ext as
     int_double binary_double; --the oracle way to specify an integer
   begin
     /*
-    if(v.is_number) then
-      myint := v.get_number;
-      return (myint = v.get_number); --no rounding errors?
+    if (v.is_number()) then
+      myint := v.get_number();
+      return (myint = v.get_number()); --no rounding errors?
     else
       return false;
     end if;
     */
+    if (not v.is_number()) then
+      raise_application_error(-20109, 'not a number-value');
+    end if;
     /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
-    if (v.is_number_repr_number) then
-      num := v.get_number;
+    if (v.is_number_repr_number()) then
+      num := v.get_number();
       int_number := trunc(num);
       --dbms_output.put_line('number: ' || num || ' -> ' || int_number);
       return (int_number = num); --no rounding errors?
-    elsif (v.is_number_repr_double) then
-      num_double := v.get_double;
+    elsif (v.is_number_repr_double()) then
+      num_double := v.get_double();
       int_double := trunc(num_double);
       --dbms_output.put_line('double: ' || num_double || ' -> ' || int_double);
       return (int_double = num_double); --no rounding errors?
@@ -79,8 +82,8 @@ create or replace package body pljson_ext as
   --conversion is needed to extract dates
   function to_date(v pljson_value) return date as
   begin
-    if(v.is_string) then
-      return standard.to_date(v.get_string, format_string);
+    if (v.is_string()) then
+      return standard.to_date(v.get_string(), format_string);
     else
       raise_application_error(-20110, 'Anydata did not contain a date-value');
     end if;
@@ -185,7 +188,7 @@ create or replace package body pljson_ext as
 
     procedure next_char as
     begin
-      if(indx <= length(json_path)) then
+      if (indx <= length(json_path)) then
         buf := substr(json_path, indx, 1);
         indx := indx + 1;
       else
@@ -193,46 +196,46 @@ create or replace package body pljson_ext as
       end if;
     end;
     --skip ws
-    procedure skipws as begin while(buf in (chr(9),chr(10),chr(13),' ')) loop next_char; end loop; end;
+    procedure skipws as begin while (buf in (chr(9), chr(10), chr(13), ' ')) loop next_char; end loop; end;
 
   begin
     next_char();
-    while(buf is not null) loop
-      if(buf = '.') then
+    while (buf is not null) loop
+      if (buf = '.') then
         next_char();
-        if(buf is null) then raise_application_error(-20110, 'JSON Path parse error: . is not a valid json_path end'); end if;
-        if(not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: . is not a valid json_path end'); end if;
+        if (not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
 
-        if(build_path != '[') then build_path := build_path || ','; end if;
+        if (build_path != '[') then build_path := build_path || ','; end if;
         build_path := build_path || '"';
-        while(regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while (regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;
         build_path := build_path || '"';
-      elsif(buf = '[') then
+      elsif (buf = '[') then
         next_char();
         skipws();
-        if(buf is null) then raise_application_error(-20110, 'JSON Path parse error: [ is not a valid json_path end'); end if;
-        if(buf in ('1','2','3','4','5','6','7','8','9') or (buf = '0' and base = 0)) then
-          if(build_path != '[') then build_path := build_path || ','; end if;
-          while(buf in ('0','1','2','3','4','5','6','7','8','9')) loop
+        if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: [ is not a valid json_path end'); end if;
+        if (buf in ('1','2','3','4','5','6','7','8','9') or (buf = '0' and base = 0)) then
+          if (build_path != '[') then build_path := build_path || ','; end if;
+          while (buf in ('0','1','2','3','4','5','6','7','8','9')) loop
             build_path := build_path || buf;
             next_char();
           end loop;
         elsif (regexp_like(buf, '^(\"|\'')', 'c')) then
           endstring := buf;
-          if(build_path != '[') then build_path := build_path || ','; end if;
+          if (build_path != '[') then build_path := build_path || ','; end if;
           build_path := build_path || '"';
           next_char();
-          if(buf is null) then raise_application_error(-20110, 'JSON Path parse error: premature json_path end'); end if;
-          while(buf != endstring) loop
+          if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: premature json_path end'); end if;
+          while (buf != endstring) loop
             build_path := build_path || buf;
             next_char();
-            if(buf is null) then raise_application_error(-20110, 'JSON Path parse error: premature json_path end'); end if;
-            if(buf = '\') then
+            if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: premature json_path end'); end if;
+            if (buf = '\') then
               next_char();
               build_path := build_path || '\' || buf;
               next_char();
@@ -244,16 +247,16 @@ create or replace package body pljson_ext as
           raise_application_error(-20110, 'JSON Path parse error: expected a string or an positive integer at '||indx);
         end if;
         skipws();
-        if(buf is null) then raise_application_error(-20110, 'JSON Path parse error: premature json_path end'); end if;
-        if(buf != ']') then raise_application_error(-20110, 'JSON Path parse error: no array ending found. found: '|| buf); end if;
+        if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: premature json_path end'); end if;
+        if (buf != ']') then raise_application_error(-20110, 'JSON Path parse error: no array ending found. found: '|| buf); end if;
         next_char();
         skipws();
-      elsif(build_path = '[') then
-        if(not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+      elsif (build_path = '[') then
+        if (not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
         build_path := build_path || '"';
-        while(regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while (regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;
@@ -268,15 +271,15 @@ create or replace package body pljson_ext as
     build_path := replace(replace(replace(replace(replace(build_path, chr(9), '\t'), chr(10), '\n'), chr(13), '\f'), chr(8), '\b'), chr(14), '\r');
 
     ret := pljson_list(build_path);
-    if(base != 1) then
+    if (base != 1) then
       --fix base 0 to base 1
       declare
         elem pljson_value;
       begin
         for i in 1 .. ret.count loop
           elem := ret.get(i);
-          if(elem.is_number) then
-            ret.replace(i,elem.get_number()+1);
+          if (elem.is_number()) then
+            ret.replace(i, elem.get_number()+1);
           end if;
         end loop;
       end;
@@ -293,16 +296,16 @@ create or replace package body pljson_ext as
   begin
     path := parsePath(v_path, base);
     ret := obj.to_json_value;
-    if(path.count = 0) then return ret; end if;
+    if (path.count = 0) then return ret; end if;
 
     for i in 1 .. path.count loop
-      if(path.get(i).is_string()) then
+      if (path.get(i).is_string()) then
         --string fetch only on json
         o := pljson(ret);
         ret := o.get(path.get(i).get_string());
       else
         --number fetch on json and json_list
-        if(ret.is_array()) then
+        if (ret.is_array()) then
           l := pljson_list(ret);
           ret := l.get(path.get(i).get_number());
         else
@@ -326,10 +329,10 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not temp.is_string) then
+    if (temp is null or not temp.is_string()) then
       return null;
     else
-      return temp.get_string;
+      return temp.get_string();
     end if;
   end;
 
@@ -337,10 +340,10 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not temp.is_number) then
+    if (temp is null or not temp.is_number()) then
       return null;
     else
-      return temp.get_number;
+      return temp.get_number();
     end if;
   end;
 
@@ -349,10 +352,10 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not temp.is_number) then
+    if (temp is null or not temp.is_number()) then
       return null;
     else
-      return temp.get_double;
+      return temp.get_double();
     end if;
   end;
 
@@ -360,7 +363,7 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not temp.is_object) then
+    if (temp is null or not temp.is_object()) then
       return null;
     else
       return pljson(temp);
@@ -371,7 +374,7 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not temp.is_array) then
+    if (temp is null or not temp.is_array()) then
       return null;
     else
       return pljson_list(temp);
@@ -382,10 +385,10 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not temp.is_bool) then
+    if (temp is null or not temp.is_bool()) then
       return null;
     else
-      return temp.get_bool;
+      return temp.get_bool();
     end if;
   end;
 
@@ -393,7 +396,7 @@ create or replace package body pljson_ext as
     temp pljson_value;
   begin
     temp := get_json_value(obj, path, base);
-    if(temp is null or not is_date(temp)) then
+    if (temp is null or not is_date(temp)) then
       return null;
     else
       return pljson_ext.to_date(temp);
@@ -413,7 +416,7 @@ create or replace package body pljson_ext as
     inserter pljson_value;
   begin
     path := pljson_ext.parsePath(v_path, base);
-    if(path.count = 0) then raise_application_error(-20110, 'PLJSON_EXT put error: cannot put with empty string.'); end if;
+    if (path.count = 0) then raise_application_error(-20110, 'PLJSON_EXT put error: cannot put with empty string.'); end if;
 
     --build backreference
     for i in 1 .. path.count loop
@@ -422,27 +425,27 @@ create or replace package body pljson_ext as
       if (keyval.is_number()) then
         --number index
         keynum := keyval.get_number();
-        if((not temp.is_object()) and (not temp.is_array())) then
-          if(val is null) then return; end if;
+        if ((not temp.is_object()) and (not temp.is_array())) then
+          if (val is null) then return; end if;
           backreference.remove_last;
-          temp := pljson_list().to_json_value();
+          temp := pljson_list().to_json_value;
           backreference.append(temp);
         end if;
 
-        if(temp.is_object()) then
+        if (temp.is_object()) then
           obj_temp := pljson(temp);
-          if(obj_temp.count < keynum) then
-            if(val is null) then return; end if;
+          if (obj_temp.count < keynum) then
+            if (val is null) then return; end if;
             raise_application_error(-20110, 'PLJSON_EXT put error: access object with too few members.');
           end if;
           temp := obj_temp.get(keynum);
         else
           list_temp := pljson_list(temp);
-          if(list_temp.count < keynum) then
-            if(val is null) then return; end if;
+          if (list_temp.count < keynum) then
+            if (val is null) then return; end if;
             --raise error or quit if val is null
             for i in list_temp.count+1 .. keynum loop
-              list_temp.append(pljson_value.makenull);
+              list_temp.append(pljson_value());
             end loop;
             backreference.remove_last;
             backreference.append(list_temp);
@@ -453,11 +456,11 @@ create or replace package body pljson_ext as
       else
         --string index
         keystring := keyval.get_string();
-        if(not temp.is_object()) then
+        if (not temp.is_object()) then
           --backreference.print;
-          if(val is null) then return; end if;
+          if (val is null) then return; end if;
           backreference.remove_last;
-          temp := pljson().to_json_value();
+          temp := pljson().to_json_value;
           backreference.append(temp);
           --raise_application_error(-20110, 'PLJSON_EXT put error: trying to access a non object with a string.');
         end if;
@@ -465,11 +468,11 @@ create or replace package body pljson_ext as
         temp := obj_temp.get(keystring);
       end if;
 
-      if(temp is null) then
-        if(val is null) then return; end if;
+      if (temp is null) then
+        if (val is null) then return; end if;
         --what to expect?
         keyval := path.get(i+1);
-        if(keyval is not null and keyval.is_number()) then
+        if (keyval is not null and keyval.is_number()) then
           temp := pljson_list().to_json_value;
         else
           temp := pljson().to_json_value;
@@ -485,9 +488,9 @@ create or replace package body pljson_ext as
     inserter := val;
     for i in reverse 1 .. backreference.count loop
       -- inserter.print(false);
-      if( i = 1 ) then
+      if ( i = 1 ) then
         keyval := path.get(1);
-        if(keyval.is_string()) then
+        if (keyval.is_string()) then
           keystring := keyval.get_string();
         else
           keynum := keyval.get_number();
@@ -497,13 +500,13 @@ create or replace package body pljson_ext as
             keystring := t1.mapname;
           end;
         end if;
-        if(inserter is null) then obj.remove(keystring); else obj.put(keystring, inserter); end if;
+        if (inserter is null) then obj.remove(keystring); else obj.put(keystring, inserter); end if;
       else
         temp := backreference.get(i-1);
-        if(temp.is_object()) then
+        if (temp.is_object()) then
           keyval := path.get(i);
           obj_temp := pljson(temp);
-          if(keyval.is_string()) then
+          if (keyval.is_string()) then
             keystring := keyval.get_string();
           else
             keynum := keyval.get_number();
@@ -513,9 +516,9 @@ create or replace package body pljson_ext as
               keystring := t1.mapname;
             end;
           end if;
-          if(inserter is null) then
+          if (inserter is null) then
             obj_temp.remove(keystring);
-            if(obj_temp.count > 0) then inserter := obj_temp.to_json_value; end if;
+            if (obj_temp.count > 0) then inserter := obj_temp.to_json_value; end if;
           else
             obj_temp.put(keystring, inserter);
             inserter := obj_temp.to_json_value;
@@ -525,11 +528,11 @@ create or replace package body pljson_ext as
           keynum := path.get(i).get_number();
           list_temp := pljson_list(temp);
           list_temp.remove(keynum);
-          if(not inserter is null) then
+          if (not inserter is null) then
             list_temp.append(inserter, keynum);
             inserter := list_temp.to_json_value;
           else
-            if(list_temp.count > 0) then inserter := list_temp.to_json_value; end if;
+            if (list_temp.count > 0) then inserter := list_temp.to_json_value; end if;
           end if;
         end if;
       end if;
@@ -542,18 +545,18 @@ create or replace package body pljson_ext as
   procedure put(obj in out nocopy pljson, path varchar2, elem varchar2, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, pljson_value(elem), base);
+      put_internal(obj, path, pljson_value(elem), base);
     end if;
   end;
 
   procedure put(obj in out nocopy pljson, path varchar2, elem number, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, pljson_value(elem), base);
+      put_internal(obj, path, pljson_value(elem), base);
     end if;
   end;
 
@@ -561,61 +564,61 @@ create or replace package body pljson_ext as
   procedure put(obj in out nocopy pljson, path varchar2, elem binary_double, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, pljson_value(elem), base);
+      put_internal(obj, path, pljson_value(elem), base);
     end if;
   end;
 
   procedure put(obj in out nocopy pljson, path varchar2, elem pljson, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, elem.to_json_value, base);
+      put_internal(obj, path, elem.to_json_value, base);
     end if;
   end;
 
   procedure put(obj in out nocopy pljson, path varchar2, elem pljson_list, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, elem.to_json_value, base);
+      put_internal(obj, path, elem.to_json_value, base);
     end if;
   end;
 
   procedure put(obj in out nocopy pljson, path varchar2, elem boolean, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, pljson_value(elem), base);
+      put_internal(obj, path, pljson_value(elem), base);
     end if;
   end;
 
   procedure put(obj in out nocopy pljson, path varchar2, elem pljson_value, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, elem, base);
+      put_internal(obj, path, elem, base);
     end if;
   end;
 
   procedure put(obj in out nocopy pljson, path varchar2, elem date, base number default 1) as
   begin
     if elem is null then
-        put_internal(obj, path, pljson_value(), base);
+      put_internal(obj, path, pljson_value(), base);
     else
-        put_internal(obj, path, pljson_ext.to_json_value(elem), base);
+      put_internal(obj, path, pljson_ext.to_json_value(elem), base);
     end if;
   end;
 
   procedure remove(obj in out nocopy pljson, path varchar2, base number default 1) as
   begin
-    pljson_ext.put_internal(obj,path,null,base);
---    if(json_ext.get_json_value(obj,path) is not null) then
+    pljson_ext.put_internal(obj, path, null, base);
+--    if (json_ext.get_json_value(obj, path) is not null) then
 --    end if;
   end remove;
 
@@ -624,7 +627,7 @@ create or replace package body pljson_ext as
     json_part pljson_value;
   begin
     json_part := pljson_ext.get_json_value(obj, v_path);
-    if(json_part is null) then
+    if (json_part is null) then
       return '';
     else
       return pljson_printer.pretty_print_any(json_part); --escapes a possible internal string
@@ -641,7 +644,9 @@ create or replace package body pljson_ext as
     json_part pljson_value;
   begin
     json_part := pljson_ext.get_json_value(obj, v_path);
-    if(json_part is null) then htp.print; else
+    if (json_part is null) then
+      htp.print;
+    else
       htp.print(pljson_printer.pretty_print_any(json_part, false));
     end if;
   end pp_htp;
@@ -659,7 +664,7 @@ create or replace package body pljson_ext as
     v_amount := DBMS_LOB.GETLENGTH(c);
     v_clob_offset := 1;
     --dbms_output.put_line('V amount: '||v_amount);
-    while(v_clob_offset < v_amount) loop
+    while (v_clob_offset < v_amount) loop
       --dbms_output.put_line(v_offset);
       --temp := ;
       --dbms_output.put_line('size: '||length(temp));
@@ -702,23 +707,27 @@ create or replace package body pljson_ext as
 
   --dbms_output.put_line(obj.count);
   --dbms_output.put_line(obj.get_last().to_char);
-    dbms_lob.freetemporary(c);
+    /*dbms_lob.freetemporary(c);*/
     return obj;
   end encode;
 
   function decode(v pljson_value) return blob as
-    c clob := empty_clob();
+    --c clob := empty_clob();
+    c clob;
     b_ret blob;
 
     v_lang_context NUMBER := 0; --DBMS_LOB.DEFAULT_LANG_CTX;
 --    v_amount PLS_INTEGER;
   begin
+    /*
     dbms_lob.createtemporary(c, false, dbms_lob.call);
     v.get_string(c);
+    */
+    c := v.get_clob();
 --    v_amount := DBMS_LOB.GETLENGTH(c);
 --    dbms_output.put_line('L C'||v_amount);
     b_ret := decodeBase64Clob2Blob(c);
-    dbms_lob.freetemporary(c);
+    /*dbms_lob.freetemporary(c);*/
     return b_ret;
 
   end decode;
@@ -740,6 +749,6 @@ create or replace package body pljson_ext as
       lang_context => v_lang_context,
       warning => v_warning);
   end;
-
 end pljson_ext;
 /
+show err

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -53,6 +53,7 @@ create or replace type pljson_list force under pljson_element (
   /** Private variable for internal processing. */
   list_data pljson_value_array,
 
+  /* constructors */
   /**
    * <p>Create an empty list.</p>
    *
@@ -127,66 +128,78 @@ create or replace type pljson_list force under pljson_element (
    * @return An instance of <code>pljson_list</code>.
    */
   constructor function pljson_list(elem pljson_value) return self as result,
-
+  
+  /* list management */
   member procedure append(self in out nocopy pljson_list, elem pljson_value, position pls_integer default null),
   member procedure append(self in out nocopy pljson_list, elem varchar2, position pls_integer default null),
+  member procedure append(self in out nocopy pljson_list, elem clob, position pls_integer default null),
   member procedure append(self in out nocopy pljson_list, elem number, position pls_integer default null),
   /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
   member procedure append(self in out nocopy pljson_list, elem binary_double, position pls_integer default null),
   member procedure append(self in out nocopy pljson_list, elem boolean, position pls_integer default null),
   member procedure append(self in out nocopy pljson_list, elem pljson_list, position pls_integer default null),
-
+  
   member procedure replace(self in out nocopy pljson_list, position pls_integer, elem pljson_value),
   member procedure replace(self in out nocopy pljson_list, position pls_integer, elem varchar2),
+  member procedure replace(self in out nocopy pljson_list, position pls_integer, elem clob),
   member procedure replace(self in out nocopy pljson_list, position pls_integer, elem number),
   /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
   member procedure replace(self in out nocopy pljson_list, position pls_integer, elem binary_double),
   member procedure replace(self in out nocopy pljson_list, position pls_integer, elem boolean),
   member procedure replace(self in out nocopy pljson_list, position pls_integer, elem pljson_list),
-
-  member function count return number,
+  
   member procedure remove(self in out nocopy pljson_list, position pls_integer),
   member procedure remove_first(self in out nocopy pljson_list),
   member procedure remove_last(self in out nocopy pljson_list),
+  
+  member function count return number,
   member function get(position pls_integer) return pljson_value,
+  member function get_string(position pls_integer) return varchar2,
+  member function get_clob(position pls_integer) return clob,
+  member function get_number(position pls_integer) return number,
+  member function get_double(position pls_integer) return binary_double,
+  member function get_bool(position pls_integer) return boolean,
+  member function get_pljson_list(position pls_integer) return pljson_list,
   member function head return pljson_value,
   member function last return pljson_value,
   member function tail return pljson_list,
-
-  /* Output methods */
+  
+  member function to_json_value return pljson_value,
+  
+  /* output methods */
   member function to_char(spaces boolean default true, chars_per_line number default 0) return varchar2,
   member procedure to_clob(self in pljson_list, buf in out nocopy clob, spaces boolean default false, chars_per_line number default 0, erase_clob boolean default true),
   member procedure print(self in pljson_list, spaces boolean default true, chars_per_line number default 8192, jsonp varchar2 default null), --32512 is maximum
   member procedure htp(self in pljson_list, spaces boolean default false, chars_per_line number default 0, jsonp varchar2 default null),
-
+  
   /* json path */
   member function path(json_path varchar2, base number default 1) return pljson_value,
   /* json path_put */
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem pljson_value, base number default 1),
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem varchar2, base number default 1),
+  member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem clob, base number default 1),
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem number, base number default 1),
   /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem binary_double, base number default 1),
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem boolean, base number default 1),
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem pljson_list, base number default 1),
-
+  
   /* json path_remove */
-  member procedure path_remove(self in out nocopy pljson_list, json_path varchar2, base number default 1),
-
-  member function to_json_value return pljson_value
+  member procedure path_remove(self in out nocopy pljson_list, json_path varchar2, base number default 1)
+  
   /* --backwards compatibility
   member procedure add_elem(self in out nocopy json_list, elem json_value, position pls_integer default null),
   member procedure add_elem(self in out nocopy json_list, elem varchar2, position pls_integer default null),
   member procedure add_elem(self in out nocopy json_list, elem number, position pls_integer default null),
   member procedure add_elem(self in out nocopy json_list, elem boolean, position pls_integer default null),
   member procedure add_elem(self in out nocopy json_list, elem json_list, position pls_integer default null),
-
+  
   member procedure set_elem(self in out nocopy json_list, position pls_integer, elem json_value),
   member procedure set_elem(self in out nocopy json_list, position pls_integer, elem varchar2),
   member procedure set_elem(self in out nocopy json_list, position pls_integer, elem number),
   member procedure set_elem(self in out nocopy json_list, position pls_integer, elem boolean),
   member procedure set_elem(self in out nocopy json_list, position pls_integer, elem json_list),
-
+  
   member procedure remove_elem(self in out nocopy json_list, position pls_integer),
   member function get_elem(position pls_integer) return json_value,
   member function get_first return json_value,
@@ -195,4 +208,4 @@ create or replace type pljson_list force under pljson_element (
 
 ) not final;
 /
-sho err
+show err

--- a/src/pljson_parser.decl.sql
+++ b/src/pljson_parser.decl.sql
@@ -64,3 +64,4 @@ create or replace package pljson_parser as
 
 end pljson_parser;
 /
+show err

--- a/src/pljson_printer.package.sql
+++ b/src/pljson_printer.package.sql
@@ -39,6 +39,7 @@ create or replace package pljson_printer as
 
 end pljson_printer;
 /
+show err
 
 create or replace package body pljson_printer as
   max_line_len number := 0;
@@ -58,8 +59,8 @@ create or replace package body pljson_printer as
   
   function llcheck(str in varchar2) return varchar2 as
   begin
-    --dbms_output.put_line(cur_line_len || ' : '|| str);
-    if(max_line_len > 0 and length(str)+cur_line_len > max_line_len) then
+    --dbms_output.put_line(cur_line_len || ' : ' || str);
+    if (max_line_len > 0 and length(str)+cur_line_len > max_line_len) then
       cur_line_len := length(str);
       return newline_char || str;
     else
@@ -86,10 +87,10 @@ create or replace package body pljson_printer as
       when chr(12) then result := '\f';
       when chr(13) then result := '\r';
       when chr(34) then result := '\"';
-      when chr(47) then if(escape_solidus) then result := '\/'; end if;
+      when chr(47) then if (escape_solidus) then result := '\/'; end if;
       when chr(92) then result := '\\';
-      else if(ascii(ch) < 32) then
-             result :=  '\u'||replace(substr(to_char(ascii(ch), 'XXXX'),2,4), ' ', '0');
+      else if (ascii(ch) < 32) then
+             result :=  '\u' || replace(substr(to_char(ascii(ch), 'XXXX'), 2, 4), ' ', '0');
         elsif (ascii_output) then
              result := replace(asciistr(ch), '\', '\u');
         end if;
@@ -102,7 +103,7 @@ create or replace package body pljson_printer as
     buf varchar2(40);
     ch varchar2(1 char); /* unicode char */
   begin
-    if(str is null) then return ''; end if;
+    if (str is null) then return ''; end if;
     
     -- clear the cache if global parameters have been changed
     if char_map_escape_solidus <> escape_solidus or
@@ -133,7 +134,7 @@ create or replace package body pljson_printer as
   function newline(spaces boolean) return varchar2 as
   begin
     cur_line_len := 0;
-    if(spaces) then return newline_char; else return ''; end if;
+    if (spaces) then return newline_char; else return ''; end if;
   end;
   
 /*  function get_schema return varchar2 as
@@ -144,19 +145,19 @@ create or replace package body pljson_printer as
   function tab(indent number, spaces boolean) return varchar2 as
     i varchar(200) := '';
   begin
-    if(not spaces) then return ''; end if;
+    if (not spaces) then return ''; end if;
     for x in 1 .. indent loop i := i || indent_string; end loop;
     return i;
   end;
   
   function getCommaSep(spaces boolean) return varchar2 as
   begin
-    if(spaces) then return ', '; else return ','; end if;
+    if (spaces) then return ', '; else return ','; end if;
   end;
   
   function getMemName(mem pljson_value, spaces boolean) return varchar2 as
   begin
-    if(spaces) then
+    if (spaces) then
       return llcheck('"'||escapeString(mem.mapname)||'"') || llcheck(' : ');
     else
       return llcheck('"'||escapeString(mem.mapname)||'"') || llcheck(':');
@@ -166,7 +167,7 @@ create or replace package body pljson_printer as
   /* Clob method start here */
   procedure add_to_clob(buf_lob in out nocopy clob, buf_str in out nocopy varchar2, str varchar2) as
   begin
-    if(lengthb(str) > 32767 - lengthb(buf_str)) then
+    if (lengthb(str) > 32767 - lengthb(buf_str)) then
 --      dbms_lob.append(buf_lob, buf_str);
       dbms_lob.writeappend(buf_lob, length(buf_str), buf_str);
       buf_str := str;
@@ -193,10 +194,10 @@ create or replace package body pljson_printer as
       add_to_clob(buf, buf_str, 'null');
     else
       add_to_clob(buf, buf_str, case when elem.num = 1 then '"' else '/**/' end);
-      if(elem.extended_str is not null) then --clob implementation
-        while(offset <= dbms_lob.getlength(elem.extended_str)) loop
+      if (elem.extended_str is not null) then --clob implementation
+        while (offset <= dbms_lob.getlength(elem.extended_str)) loop
           dbms_lob.read(elem.extended_str, amount, offset, v_str);
-          if(elem.num = 1) then
+          if (elem.num = 1) then
             add_to_clob(buf, buf_str, escapeString(v_str));
           else
             add_to_clob(buf, buf_str, v_str);
@@ -204,8 +205,8 @@ create or replace package body pljson_printer as
           offset := offset + amount;
         end loop;
       else
-        if(elem.num = 1) then
-          while(offset<=length(elem.str)) loop
+        if (elem.num = 1) then
+          while (offset <= length(elem.str)) loop
             v_str:=substr(elem.str, offset, amount);
             add_to_clob(buf, buf_str, escapeString(v_str));
             offset := offset + amount;
@@ -225,31 +226,38 @@ create or replace package body pljson_printer as
   begin
     for y in 1 .. arr.count loop
       elem := arr(y);
-      if(elem is not null) then
-      case elem.get_type
-        when 'number' then
-          numbuf := elem.number_toString;
+      if (elem is not null) then
+      case elem.typeval
+        /* number */
+        when 4 then
+          numbuf := elem.number_toString();
           add_to_clob(buf, buf_str, llcheck(numbuf));
-        when 'string' then
+        /* string */
+        when 3 then
           ppString(elem, buf, buf_str);
-        when 'bool' then
-          if(elem.get_bool) then
+        /* bool */
+        when 5 then
+          if (elem.get_bool()) then
             add_to_clob(buf, buf_str, llcheck('true'));
           else
             add_to_clob(buf, buf_str, llcheck('false'));
           end if;
-        when 'null' then
+        /* null */
+        when 6 then
           add_to_clob(buf, buf_str, llcheck('null'));
-        when 'array' then
+        /* array */
+        when 2 then
           add_to_clob(buf, buf_str, llcheck('['));
           ppEA(pljson_list(elem), indent, buf, spaces, buf_str);
           add_to_clob(buf, buf_str, llcheck(']'));
-        when 'object' then
+        /* object */
+        when 1 then
           ppObj(pljson(elem), indent, buf, spaces, buf_str);
-        else add_to_clob(buf, buf_str, llcheck(elem.get_type));
+        else
+          add_to_clob(buf, buf_str, llcheck(elem.get_type));
       end case;
       end if;
-      if(y != arr.count) then add_to_clob(buf, buf_str, llcheck(getCommaSep(spaces))); end if;
+      if (y != arr.count) then add_to_clob(buf, buf_str, llcheck(getCommaSep(spaces))); end if;
     end loop;
   end ppEA;
   
@@ -257,27 +265,34 @@ create or replace package body pljson_printer as
     numbuf varchar2(4000);
   begin
     add_to_clob(buf, buf_str, llcheck(tab(indent, spaces)) || llcheck(getMemName(mem, spaces)));
-    case mem.get_type
-      when 'number' then
-        numbuf := mem.number_toString;
+    case mem.typeval
+      /* number */
+      when 4 then
+        numbuf := mem.number_toString();
         add_to_clob(buf, buf_str, llcheck(numbuf));
-      when 'string' then
+      /* string */
+      when 3 then
         ppString(mem, buf, buf_str);
-      when 'bool' then
-        if(mem.get_bool) then
+      /* bool */
+      when 5 then
+        if (mem.get_bool()) then
           add_to_clob(buf, buf_str, llcheck('true'));
         else
           add_to_clob(buf, buf_str, llcheck('false'));
         end if;
-      when 'null' then
+      /* null */
+      when 6 then
         add_to_clob(buf, buf_str, llcheck('null'));
-      when 'array' then
+      /* array */
+      when 2 then
         add_to_clob(buf, buf_str, llcheck('['));
         ppEA(pljson_list(mem), indent, buf, spaces, buf_str);
         add_to_clob(buf, buf_str, llcheck(']'));
-      when 'object' then
+      /* object */
+      when 1 then
         ppObj(pljson(mem), indent, buf, spaces, buf_str);
-      else add_to_clob(buf, buf_str, llcheck(mem.get_type));
+      else
+        add_to_clob(buf, buf_str, llcheck(mem.get_type));
     end case;
   end ppMem;
   
@@ -286,7 +301,7 @@ create or replace package body pljson_printer as
     add_to_clob(buf, buf_str, llcheck('{') || newline(spaces));
     for m in 1 .. obj.json_data.count loop
       ppMem(obj.json_data(m), indent+1, buf, spaces, buf_str);
-      if(m != obj.json_data.count) then
+      if (m != obj.json_data.count) then
         add_to_clob(buf, buf_str, llcheck(',') || newline(spaces));
       else
         add_to_clob(buf, buf_str, newline(spaces));
@@ -299,7 +314,7 @@ create or replace package body pljson_printer as
     buf_str varchar2(32767);
     amount number := dbms_lob.getlength(buf);
   begin
-    if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
+    if (erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
     
     max_line_len := line_length;
     cur_line_len := 0;
@@ -311,7 +326,7 @@ create or replace package body pljson_printer as
     buf_str varchar2(32767);
     amount number := dbms_lob.getlength(buf);
   begin
-    if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
+    if (erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
     
     max_line_len := line_length;
     cur_line_len := 0;
@@ -326,29 +341,36 @@ create or replace package body pljson_printer as
     numbuf varchar2(4000);
     amount number := dbms_lob.getlength(buf);
   begin
-    if(erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
+    if (erase_clob and amount > 0) then dbms_lob.trim(buf, 0); dbms_lob.erase(buf, amount); end if;
     
-    case json_part.get_type
-      when 'number' then
-        numbuf := json_part.number_toString;
+    case json_part.typeval
+      /* number */
+      when 4 then
+        numbuf := json_part.number_toString();
         add_to_clob(buf, buf_str, numbuf);
-      when 'string' then
+      /* string */
+      when 3 then
         ppString(json_part, buf, buf_str);
-      when 'bool' then
-        if(json_part.get_bool) then
+      /* bool */
+      when 5 then
+        if (json_part.get_bool()) then
           add_to_clob(buf, buf_str, 'true');
         else
           add_to_clob(buf, buf_str, 'false');
         end if;
-      when 'null' then
+      /* null */
+      when 6 then
         add_to_clob(buf, buf_str, 'null');
-      when 'array' then
+      /* array */
+      when 2 then
         pretty_print_list(pljson_list(json_part), spaces, buf, line_length);
         return;
-      when 'object' then
+      /* object */
+      when 1 then
         pretty_print(pljson(json_part), spaces, buf, line_length);
         return;
-      else add_to_clob(buf, buf_str, 'unknown type:'|| json_part.get_type);
+      else
+        add_to_clob(buf, buf_str, 'unknown type:' || json_part.get_type);
     end case;
     flush_clob(buf, buf_str);
   end;
@@ -358,7 +380,7 @@ create or replace package body pljson_printer as
   /* Varchar2 method start here */
   procedure add_buf (buf in out nocopy varchar2, str in varchar2) as
   begin
-    if(lengthb(str)>32767-lengthb(buf)) then
+    if (lengthb(str)>32767-lengthb(buf)) then
       raise_application_error(-20001,'Length of result JSON more than 32767 bytes. Use to_clob() procedures');
     end if;
     buf := buf || str;
@@ -374,10 +396,10 @@ create or replace package body pljson_printer as
       add_buf(buf, 'null');
     else
       add_buf(buf, case when elem.num = 1 then '"' else '/**/' end);
-      if(elem.extended_str is not null) then --clob implementation
-        while(offset <= dbms_lob.getlength(elem.extended_str)) loop
+      if (elem.extended_str is not null) then --clob implementation
+        while (offset <= dbms_lob.getlength(elem.extended_str)) loop
           dbms_lob.read(elem.extended_str, amount, offset, v_str);
-          if(elem.num = 1) then
+          if (elem.num = 1) then
             add_buf(buf, escapeString(v_str));
           else
             add_buf(buf, v_str);
@@ -385,8 +407,8 @@ create or replace package body pljson_printer as
           offset := offset + amount;
         end loop;
       else
-        if(elem.num = 1) then
-          while(offset<=length(elem.str)) loop
+        if (elem.num = 1) then
+          while (offset <= length(elem.str)) loop
             v_str:=substr(elem.str, offset, amount);
             add_buf(buf, escapeString(v_str));
             offset := offset + amount;
@@ -408,31 +430,38 @@ create or replace package body pljson_printer as
   begin
     for y in 1 .. arr.count loop
       elem := arr(y);
-      if(elem is not null) then
-      case elem.get_type
-        when 'number' then
-          str := elem.number_toString;
+      if (elem is not null) then
+      case elem.typeval
+        /* number */
+        when 4 then
+          str := elem.number_toString();
           add_buf(buf, llcheck(str));
-        when 'string' then
+        /* string */
+        when 3 then
           ppString(elem, buf);
-        when 'bool' then
-          if(elem.get_bool) then
+        /* bool */
+        when 5 then
+          if (elem.get_bool()) then
             add_buf (buf, llcheck('true'));
           else
             add_buf (buf, llcheck('false'));
           end if;
-        when 'null' then
+        /* null */
+        when 6 then
           add_buf (buf, llcheck('null'));
-        when 'array' then
+        /* array */
+        when 2 then
           add_buf( buf, llcheck('['));
           ppEA(pljson_list(elem), indent, buf, spaces);
           add_buf( buf, llcheck(']'));
-        when 'object' then
+        /* object */
+        when 1 then
           ppObj(pljson(elem), indent, buf, spaces);
-        else add_buf (buf, llcheck(elem.get_type)); /* should never happen */
+        else
+          add_buf (buf, llcheck(elem.get_type)); /* should never happen */
       end case;
       end if;
-      if(y != arr.count) then add_buf(buf, llcheck(getCommaSep(spaces))); end if;
+      if (y != arr.count) then add_buf(buf, llcheck(getCommaSep(spaces))); end if;
     end loop;
   end ppEA;
   
@@ -440,27 +469,34 @@ create or replace package body pljson_printer as
     str varchar2(400) := '';
   begin
     add_buf(buf, llcheck(tab(indent, spaces)) || getMemName(mem, spaces));
-    case mem.get_type
-      when 'number' then
-        str := mem.number_toString;
+    case mem.typeval
+      /* number */
+      when 4 then
+        str := mem.number_toString();
         add_buf(buf, llcheck(str));
-      when 'string' then
+      /* string */
+      when 3 then
         ppString(mem, buf);
-      when 'bool' then
-        if(mem.get_bool) then
+      /* bool */
+      when 5 then
+        if (mem.get_bool()) then
           add_buf(buf, llcheck('true'));
         else
           add_buf(buf, llcheck('false'));
         end if;
-      when 'null' then
+      /* null */
+      when 6 then
         add_buf(buf, llcheck('null'));
-      when 'array' then
+      /* array */
+      when 2 then
         add_buf(buf, llcheck('['));
         ppEA(pljson_list(mem), indent, buf, spaces);
         add_buf(buf, llcheck(']'));
-      when 'object' then
+      /* object */
+      when 1 then
         ppObj(pljson(mem), indent, buf, spaces);
-      else add_buf(buf, llcheck(mem.get_type)); /* should never happen */
+      else
+        add_buf(buf, llcheck(mem.get_type)); /* should never happen */
     end case;
   end ppMem;
   
@@ -469,8 +505,11 @@ create or replace package body pljson_printer as
     add_buf (buf, llcheck('{') || newline(spaces));
     for m in 1 .. obj.json_data.count loop
       ppMem(obj.json_data(m), indent+1, buf, spaces);
-      if(m != obj.json_data.count) then add_buf(buf, llcheck(',') || newline(spaces));
-      else add_buf(buf, newline(spaces)); end if;
+      if (m != obj.json_data.count) then
+        add_buf(buf, llcheck(',') || newline(spaces));
+      else
+        add_buf(buf, newline(spaces));
+      end if;
     end loop;
     add_buf(buf, llcheck(tab(indent, spaces)) || llcheck('}')); -- || chr(13);
   end ppObj;
@@ -498,20 +537,27 @@ create or replace package body pljson_printer as
   function pretty_print_any(json_part pljson_value, spaces boolean default true, line_length number default 0) return varchar2 as
     buf varchar2(32767) := '';
   begin
-    case json_part.get_type
-      when 'number' then
-        buf := json_part.number_toString;
-      when 'string' then
+    case json_part.typeval
+      /* number */
+      when 4 then
+        buf := json_part.number_toString();
+      /* string */
+      when 3 then
         ppString(json_part, buf);
-      when 'bool' then
-        if(json_part.get_bool) then buf := 'true'; else buf := 'false'; end if;
-      when 'null' then
+      /* bool */
+      when 5 then
+        if (json_part.get_bool()) then buf := 'true'; else buf := 'false'; end if;
+      /* null */
+      when 6 then
         buf := 'null';
-      when 'array' then
+      /* array */
+      when 2 then
         buf := pretty_print_list(pljson_list(json_part), spaces, line_length);
-      when 'object' then
+      /* object */
+      when 1 then
         buf := pretty_print(pljson(json_part), spaces, line_length);
-      else buf := 'weird error: '|| json_part.get_type;
+      else
+        buf := 'weird error: ' || json_part.get_type;
     end case;
     return buf;
   end;
@@ -523,13 +569,13 @@ create or replace package body pljson_printer as
     v_str varchar2(32767);
     amount number := 8191; /* max unicode chars */
   begin
-    if(jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
-    while(indx != 0) loop
+    if (jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
+    while (indx != 0) loop
       --read every line
       indx := dbms_lob.instr(my_clob, delim, prev+1);
       --dbms_output.put_line(prev || ' to ' || indx);
       
-      if(indx = 0) then
+      if (indx = 0) then
         --emit from prev to end;
         amount := 8191; /* max unicode chars */
         --dbms_output.put_line(' mycloblen ' || dbms_lob.getlength(my_clob));
@@ -541,7 +587,7 @@ create or replace package body pljson_printer as
         end loop;
       else
         amount := indx - prev;
-        if(amount > 8191) then /* max unicode chars */
+        if (amount > 8191) then /* max unicode chars */
           amount := 8191; /* max unicode chars */
           --dbms_output.put_line(' mycloblen ' || dbms_lob.getlength(my_clob));
           loop
@@ -550,7 +596,7 @@ create or replace package body pljson_printer as
             prev := prev+amount-1;
             amount := indx - prev;
             exit when prev >= indx - 1;
-            if(amount > 8191) then amount := 8191; end if; /* max unicode chars */
+            if (amount > 8191) then amount := 8191; end if; /* max unicode chars */
           end loop;
           prev := indx + size_of_nl;
         else
@@ -561,16 +607,16 @@ create or replace package body pljson_printer as
       end if;
     
     end loop;
-    if(jsonp is not null) then dbms_output.put_line(')'); end if;
+    if (jsonp is not null) then dbms_output.put_line(')'); end if;
     
 /*    while (amount != 0) loop
       indx := dbms_lob.instr(my_clob, delim, prev+1);
 
 --      dbms_output.put_line(prev || ' to ' || indx);
-      if(indx = 0) then
+      if (indx = 0) then
         indx := dbms_lob.getlength(my_clob)+1;
       end if;
-      if(indx-prev > 32767) then
+      if (indx-prev > 32767) then
         indx := prev+32767;
       end if;
 --      dbms_output.put_line(prev || ' to ' || indx);
@@ -581,9 +627,9 @@ create or replace package body pljson_printer as
       dbms_lob.read(my_clob, amount, prev, v_str);
       dbms_output.put_line(v_str);
       prev := indx+size_of_nl;
-      if(amount = 32767) then prev := prev-size_of_nl-1; end if;
+      if (amount = 32767) then prev := prev-size_of_nl-1; end if;
     end loop;
-    if(jsonp is not null) then dbms_output.put_line(')'); end if;*/
+    if (jsonp is not null) then dbms_output.put_line(')'); end if;*/
   end;
   
 /*  procedure dbms_output_clob(my_clob clob, delim varchar2, jsonp varchar2 default null) as
@@ -593,17 +639,17 @@ create or replace package body pljson_printer as
     v_str varchar2(32767);
     amount number;
   begin
-    if(jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
+    if (jsonp is not null) then dbms_output.put_line(jsonp||'('); end if;
     while (indx != 0) loop
       indx := dbms_lob.instr(my_clob, delim, prev+1);
 
       --dbms_output.put_line(prev || ' to ' || indx);
-      if(indx-prev > 32767) then
+      if (indx-prev > 32767) then
         indx := prev+32767;
       end if;
       --dbms_output.put_line(prev || ' to ' || indx);
       --substr doesnt work properly on all platforms! (come on oracle - error on Oracle VM for virtualbox)
-      if(indx = 0) then
+      if (indx = 0) then
         --dbms_output.put_line(dbms_lob.substr(my_clob, dbms_lob.getlength(my_clob)-prev+size_of_nl, prev));
         amount := dbms_lob.getlength(my_clob)-prev+size_of_nl;
         dbms_lob.read(my_clob, amount, prev, v_str);
@@ -615,9 +661,9 @@ create or replace package body pljson_printer as
       end if;
       dbms_output.put_line(v_str);
       prev := indx+size_of_nl;
-      if(amount = 32767) then prev := prev-size_of_nl-1; end if;
+      if (amount = 32767) then prev := prev-size_of_nl-1; end if;
     end loop;
-    if(jsonp is not null) then dbms_output.put_line(')'); end if;
+    if (jsonp is not null) then dbms_output.put_line(')'); end if;
   end;
 */
   
@@ -630,7 +676,7 @@ create or replace package body pljson_printer as
     l_off   number default 1;
     l_str   varchar2(32000);
   begin
-    if(jsonp is not null) then htp.prn(jsonp||'('); end if;
+    if (jsonp is not null) then htp.prn(jsonp||'('); end if;
     
     begin
       loop
@@ -649,14 +695,15 @@ create or replace package body pljson_printer as
     /*
     len := dbms_lob.getlength(my_clob);
     
-    while(pos < len) loop
+    while (pos < len) loop
       htp.prn(dbms_lob.substr(my_clob, amount, pos)); -- should I replace substr with dbms_lob.read?
       --dbms_output.put_line(dbms_lob.substr(my_clob, amount, pos));
       pos := pos + amount;
     end loop;
     */
-    if(jsonp is not null) then htp.prn(')'); end if;
+    if (jsonp is not null) then htp.prn(')'); end if;
   end;
 
 end pljson_printer;
 /
+show err

--- a/src/pljson_value.type.decl.sql
+++ b/src/pljson_value.type.decl.sql
@@ -113,9 +113,9 @@ create or replace type pljson_value force as object (
   /**
    * <p>Retrieve the value as a string (<code>varchar2</code>).</p>
    *
-   * @param max_byte_size Retreive the value up to a specific number of bytes. Default: <code>null</code>.
-   * @param max_char_size Retrieve the value up to a specific number of characters. Default: <code>null</code>.
-   * @return An instance of <code>varchar2</code> or <code>null</code> value is not a string.
+   * @param max_byte_size Retrieve the value up to a specific number of bytes, max = bytes for 5000 characters. Default: <code>null</code>.
+   * @param max_char_size Retrieve the value up to a specific number of characters, max = 5000. Default: <code>null</code>.
+   * @return An instance of <code>varchar2</code> or <code>null</code> if the value is not a string.
    */
   member function get_string(max_byte_size number default null, max_char_size number default null) return varchar2,
 
@@ -127,9 +127,16 @@ create or replace type pljson_value force as object (
   member procedure get_string(self in pljson_value, buf in out nocopy clob),
 
   /**
+   * <p>Retrieve the value as a string of clob type (<code>clob</code>).</p>
+   *
+   * @return the internal <code>clob</code> or <code>null</code> if the value is not a string.
+   */
+  member function get_clob return clob,
+
+  /**
    * <p>Retrieve the value as a <code>number</code>.</p>
    *
-   * @return An instance of <code>number</code> or <code>null</code> if the value isn't a number.
+   * @return An instance of <code>number</code> or <code>null</code> if the value is not a number.
    */
   member function get_number return number,
 
@@ -137,14 +144,14 @@ create or replace type pljson_value force as object (
   /**
    * <p>Retrieve the value as a <code>binary_double</code>.</p>
    *
-   * @return An instance of <code>binary_double</code> or <code>null</code> if the value isn't a number.
+   * @return An instance of <code>binary_double</code> or <code>null</code> if the value is not a number.
    */
   member function get_double return binary_double,
 
   /**
    * <p>Retrieve the value as a <code>boolean</code>.</p>
    *
-   * @return An instance of <code>boolean</code> or <code>null</code> if the value isn't a boolean.
+   * @return An instance of <code>boolean</code> or <code>null</code> if the value is not a boolean.
    */
   member function get_bool return boolean,
 
@@ -199,10 +206,10 @@ create or replace type pljson_value force as object (
   member function is_null return boolean,
 
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers, is_number is still true, extra info */
-  /* return true if 'number' is representable by number */
+  /* return true if 'number' is representable by Oracle number */
   /** Private method for internal processing. */
   member function is_number_repr_number return boolean,
-  /* return true if 'number' is representable by binary_double */
+  /* return true if 'number' is representable by Oracle binary_double */
   /** Private method for internal processing. */
   member function is_number_repr_double return boolean,
 

--- a/src/pljson_value.type.impl.sql
+++ b/src/pljson_value.type.impl.sql
@@ -137,6 +137,19 @@ create or replace type body pljson_value as
     end if;
   end get_string;
 
+  member function get_clob return clob as
+  begin
+    if(self.typeval = 3) then
+      if(extended_str is not null) then
+        --dbms_lob.copy(buf, extended_str, dbms_lob.getlength(extended_str));
+        return self.extended_str;
+      else
+        --dbms_lob.writeappend(buf, length(self.str), self.str);
+        return self.str;
+      end if;
+    end if;
+  end get_clob;
+
   member function get_number return number as
   begin
     if(self.typeval = 4) then
@@ -178,7 +191,7 @@ create or replace type body pljson_value as
   member function is_null return boolean as begin return self.typeval = 6; end;
 
   /* E.I.Sarmas (github.com/dsnz)   2016-11-03   support for binary_double numbers, is_number is still true, extra check */
-  /* return true if 'number' is representable by number */
+  /* return true if 'number' is representable by Oracle number */
   member function is_number_repr_number return boolean is
   begin
     if self.typeval != 4 then
@@ -187,7 +200,7 @@ create or replace type body pljson_value as
     return (num_repr_number_p = 't');
   end;
 
-  /* return true if 'number' is representable by binary_double */
+  /* return true if 'number' is representable by Oracle binary_double */
   member function is_number_repr_double return boolean is
   begin
     if self.typeval != 4 then

--- a/testsuite-utplsql/utplsql_pljson_base64_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_base64_test.sql
@@ -65,7 +65,7 @@ create or replace package body utplsql_pljson_base64_test is
     end if;
   end;
   
-  procedure base64_check(w_clob in out clob) is
+  procedure base64_check(w_clob in clob) is
     obj_json pljson;
     tmp_json pljson;
     w_json_tag varchar2(32) := 'binaryFile';
@@ -74,6 +74,7 @@ create or replace package body utplsql_pljson_base64_test is
     w_hash1 varchar2(40);
     w_hash2 varchar2(40);
     
+    w_clob_new clob;
     w_clob1 clob;
     w_clob2 clob;
     w_char varchar2(1000);
@@ -120,30 +121,29 @@ create or replace package body utplsql_pljson_base64_test is
     dbms_output.put_line('---------------------------------------------------------------');
     
     --dbms_lob.createtemporary(w_clob, true);
-    dbms_lob.trim(w_clob, 0);
+    --dbms_lob.trim(w_clob, 0);
     
     -- JSON creation/parsing  
     obj_json := new pljson();
     obj_json.put(w_json_tag, pljson_ext.encode(w_blob));
     obj_value := pljson_ext.get_json_value(obj_json, w_json_tag);
-    --pljson_value.get_string(obj_value, w_clob);
-    obj_value.get_string(w_clob);
+    w_clob_new := obj_value.get_clob();
     
     /* debugging
     dbms_output.put_line('c2>>');
-    dbms_output.put_line(dbms_lob.substr(w_clob, 200, 1));
+    dbms_output.put_line(dbms_lob.substr(w_clob_new, 200, 1));
     dbms_output.put_line('===');
-    dbms_output.put_line(dbms_lob.substr(w_clob, 200, dbms_lob.getlength(w_clob) - 199));
+    dbms_output.put_line(dbms_lob.substr(w_clob_new, 200, dbms_lob.getlength(w_clob_new) - 199));
     dbms_output.put_line('<<c2');
-    dbms_lob.copy(w_clob2, w_clob, 2000000);
+    dbms_lob.copy(w_clob2, w_clob_new, 2000000);
     
-    select dump(dbms_lob.substr(w_clob, 150, 1), 16)
+    select dump(dbms_lob.substr(w_clob_new, 150, 1), 16)
     into w_char
     from dual;
     dbms_output.put_line('c2(dump)>>' || w_char || '<<c2(dump)');
     */
     
-    w_blob := pljson_ext.decode(new pljson_value(w_clob));
+    w_blob := pljson_ext.decode(new pljson_value(w_clob_new));
     
     /* debugging
     dbms_output.put_line('b2>>' || dbms_lob.substr(w_blob, 200, 1));
@@ -831,7 +831,7 @@ create or replace package body utplsql_pljson_base64_test is
     dbms_lob.writeappend(w_clob, length(w_tmp_string), w_tmp_string);
     w_tmp_string := 'IG4gCjAwMDAyMDI4NDIgMDAwMDAgbiAKMDAwMDI5MzI4MyAwMDAwMCBuIAowMDAwNDE4ODg1IDAwMDAwIG4gCjAwMDA0MTk5MTMgMDAwMDAgbiAKMDAwMDM5MTgzMSAwMDAwMCBuIAowMDAwMzkxODYzIDAwMDAwIG4gCjAwMDAzOTI1MDUgMDAwMDAgbiAKMDAwMDM5MjM1NiAwMDAwMCBuIAowMDAwMzkyMjAzIDAwMDAwIG4gCjAwMDAyOTMzMDUgMDAwMDAgbiAKMDAwMDM4NjgzNiAwMDAwMCBuIAowMDAwNDE1ODExIDAwMDAwIG4gCjAwMDA0MTc4NjEgMDAwMDAgbiAKMDAwMDM5MjI4MSAwMDAwMCBuIAowMDAwMzkyMzEzIDAwMDAwIG4gCjAwMDAzOTU4NjMgMDAwMDAgbiAKMDAwMDM5OTIxMiAwMDAwMCBuIAowMDAwNDA2MzMyIDAwMDAwIG4gCjAwMDA0MTA1MTYgMDAwMDAgbiAKMDAwMDQxNTc5MCAwMDAwMCBuIAowMDAwNDI0MTY3IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgOTUgL1Jvb3QgMSAwIFIgL0luZm8gMiAwIFIKPj4Kc3RhcnR4cmVmCjQzMjAxNAolJUVPRgo=';
     dbms_lob.writeappend(w_clob, length(w_tmp_string), w_tmp_string);
-
+    
     base64_check(w_clob);
     
     dbms_lob.freetemporary(w_clob);
@@ -896,3 +896,4 @@ create or replace package body utplsql_pljson_base64_test is
   
 end utplsql_pljson_base64_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_ext_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_ext_test.sql
@@ -175,3 +175,4 @@ create or replace package body utplsql_pljson_ext_test is
   
 end utplsql_pljson_ext_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_helper_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_helper_test.sql
@@ -207,7 +207,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_merge_simple is
     obj pljson;
   begin
-    obj := pljson_helper.merge(pljson('{"a":1,"b":"str","c":{}}'),pljson('{"d":2,"e":"x"}'));
+    obj := pljson_helper.merge(pljson('{"a":1,"b":"str","c":{}}'), pljson('{"d":2,"e":"x"}'));
     assertTrue(obj.count = 5, 'obj.count = 5');
     assertTrue(strip_eol(obj.to_char(false)) = '{"a":1,"b":"str","c":{},"d":2,"e":"x"}', 'strip_eol(obj.to_char(false)) = ''{"a":1,"b":"str","c":{},"d":2,"e":"x"}''');
   end;
@@ -216,7 +216,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_merge_overwrites is
     obj pljson;
   begin
-    obj := pljson_helper.merge(pljson('{"a":1,"b":"x"}'),pljson('{"a":2,"c":"y"}'));
+    obj := pljson_helper.merge(pljson('{"a":1,"b":"x"}'), pljson('{"a":2,"c":"y"}'));
     assertTrue(obj.count = 3, 'obj.count = 3');
     assertTrue(obj.get('a').get_number = 2, 'obj.get(''a'').get_number = 2');
   end;
@@ -226,7 +226,7 @@ create or replace package body utplsql_pljson_helper_test is
     obj pljson;
     val pljson_value;
   begin
-    obj := pljson_helper.merge(pljson('{"a":{"a1":1,"a2":{}}}'),pljson('{"a":{"a2":{"a2a":1},"a3":2}}'));
+    obj := pljson_helper.merge(pljson('{"a":{"a1":1,"a2":{}}}'), pljson('{"a":{"a2":{"a2a":1},"a3":2}}'));
     val := obj.get('a');
     assertTrue(pljson(val).count = 3, 'pljson(val).count = 3');
     assertTrue(val.to_char(false) = '{"a1":1,"a2":{"a2a":1},"a3":2}', 'val.to_char(false) = ''{"a1":1,"a2":{"a2a":1},"a3":2}''');
@@ -236,7 +236,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_join_empty_lists is
     obj pljson_list;
   begin
-    obj := pljson_helper.join(pljson_list('[]'),pljson_list('[]'));
+    obj := pljson_helper.join(pljson_list('[]'), pljson_list('[]'));
     assertTrue(obj.count = 0, 'obj.count = 0');
   end;
   
@@ -244,7 +244,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_join_simple_lists is
     obj pljson_list;
   begin
-    obj := pljson_helper.join(pljson_list('[1,2,3]'),pljson_list('[4,5,6]'));
+    obj := pljson_helper.join(pljson_list('[1,2,3]'), pljson_list('[4,5,6]'));
     assertTrue(obj.count = 6, 'obj.count = 6');
     assertTrue(obj.to_char(false) = '[1,2,3,4,5,6]', 'obj.to_char(false) = ''[1,2,3,4,5,6]''');
   end;
@@ -253,7 +253,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_join_complex_lists is
     obj pljson_list;
   begin
-    obj := pljson_helper.join(pljson_list('[1,"2",{"a":1}]'),pljson_list('[3,"4",{"b":2}]'));
+    obj := pljson_helper.join(pljson_list('[1,"2",{"a":1}]'), pljson_list('[3,"4",{"b":2}]'));
     assertTrue(obj.count = 6, 'obj.count = 6');
     assertTrue(strip_eol(obj.to_char(false)) = '[1,"2",{"a":1},3,"4",{"b":2}]', 'strip_eol(obj.to_char(false)) = ''[1,"2",{"a":1},3,"4",{"b":2}]''');
   end;
@@ -262,7 +262,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_keep_empty_list is
     obj pljson;
   begin
-    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":{}}'),pljson_list('[]'));
+    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":{}}'), pljson_list('[]'));
     assertTrue(obj.count = 0, 'obj.count = 0');
     assertTrue(obj.to_char(false) = '{}', 'obj.to_char(false) = ''{}''');
   end;
@@ -271,7 +271,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_keep_simple_list is
     obj pljson;
   begin
-    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":3}'),pljson_list('["a","c"]'));
+    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":3}'), pljson_list('["a","c"]'));
     assertTrue(obj.count = 2, 'obj.count = 2');
     assertTrue(obj.to_char(false) = '{"a":1,"c":3}', 'obj.to_char(false) = ''{"a":1,"c":3}''');
   end;
@@ -280,7 +280,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_remove_empty_list is
     obj pljson;
   begin
-    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'),pljson_list('[]'));
+    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'), pljson_list('[]'));
     assertTrue(obj.count = 3, 'obj.count = 3');
     assertTrue(obj.to_char(false) = '{"a":1,"b":2,"c":3}', 'obj.to_char(false) = ''{"a":1,"b":2,"c":3}''');
   end;
@@ -289,7 +289,7 @@ create or replace package body utplsql_pljson_helper_test is
   procedure test_remove_simple_list is
     obj pljson;
   begin
-    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'),pljson_list('["a","c"]'));
+    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'), pljson_list('["a","c"]'));
     assertTrue(obj.count = 1, 'obj.count = 1');
     assertTrue(obj.get('b').get_number = 2, 'obj.get(''b'').get_number = 2');
   end;
@@ -297,32 +297,32 @@ create or replace package body utplsql_pljson_helper_test is
   -- equals(pljson_value, pljson_value)
   procedure test_equals_value_value is
   begin
-    assertTrue(pljson_helper.equals(pljson_value(''),pljson_value('')), 'pljson_helper.equals(pljson_value(''''),pljson_value(''''))');
-    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value,pljson('{"a":1,"b":2}').to_json_value), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value,pljson(''{"a":1,"b":2}'').to_json_value)');
+    assertTrue(pljson_helper.equals(pljson_value(''), pljson_value('')), 'pljson_helper.equals(pljson_value(''''), pljson_value(''''))');
+    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value, pljson('{"a":1,"b":2}').to_json_value), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value, pljson(''{"a":1,"b":2}'').to_json_value)');
   end;
   
   -- equals(pljson_value, pljson_value) - empty constructor
   procedure test_equals_value_value_empty is
   begin
-    assertTrue(pljson_helper.equals(pljson_value(),pljson_value()), 'pljson_helper.equals(pljson_value(),pljson_value())');
+    assertTrue(pljson_helper.equals(pljson_value(), pljson_value()), 'pljson_helper.equals(pljson_value(), pljson_value())');
   end;
   
   -- equals(pljson_value, pljson)
   procedure test_equals_value_pljson is
   begin
-    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value,pljson('{"a":1,"b":2}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value,pljson(''{"a":1,"b":2}''))');
+    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value, pljson('{"a":1,"b":2}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value, pljson(''{"a":1,"b":2}''))');
   end;
   
   -- equals(pljson_value, pljson_list)
   procedure test_equals_value_list is
   begin
-    assertTrue(pljson_helper.equals(pljson_list('[1,2,3]').to_json_value,pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]'').to_json_value,pljson_list(''[1,2,3]''))');
+    assertTrue(pljson_helper.equals(pljson_list('[1,2,3]').to_json_value, pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]'').to_json_value, pljson_list(''[1,2,3]''))');
   end;
   
   -- equals(pljson_value, number)
   procedure test_equals_value_number is
   begin
-    assertTrue(pljson_helper.equals(pljson_value(2),2), 'pljson_helper.equals(pljson_value(2),2)');
+    assertTrue(pljson_helper.equals(pljson_value(2), 2), 'pljson_helper.equals(pljson_value(2), 2)');
   end;
   
   -- equals(pljson_value, binary_double)
@@ -335,90 +335,90 @@ create or replace package body utplsql_pljson_helper_test is
   -- equals(pljson_value, varchar2)
   procedure test_equals_value_varchar2 is
   begin
-    assertTrue(pljson_helper.equals(pljson_value('xyz'),'xyz'), 'pljson_helper.equals(pljson_value(''xyz''),''xyz'')');
+    assertTrue(pljson_helper.equals(pljson_value('xyz'), 'xyz'), 'pljson_helper.equals(pljson_value(''xyz''), ''xyz'')');
   end;
   
   -- equals(pljson_value, varchar2) - empty string value
   procedure test_equals_value_varchar2_nil is
   begin
-    assertTrue(pljson_helper.equals(pljson_value(''),''), 'pljson_helper.equals(pljson_value(''''),'''')');
+    assertTrue(pljson_helper.equals(pljson_value(''), ''), 'pljson_helper.equals(pljson_value(''''), '''')');
   end;
   
   -- equals(pljson_value, boolean)
   procedure test_equals_value_boolean is
   begin
-    assertTrue(pljson_helper.equals(pljson_value(true),true), 'pljson_helper.equals(pljson_value(true),true)');
-    assertTrue(pljson_helper.equals(pljson_value(false),false), 'pljson_helper.equals(pljson_value(false),false)');
+    assertTrue(pljson_helper.equals(pljson_value(true), true), 'pljson_helper.equals(pljson_value(true), true)');
+    assertTrue(pljson_helper.equals(pljson_value(false), false), 'pljson_helper.equals(pljson_value(false), false)');
   end;
   
   -- equals(pljson_value, clob)
   procedure test_equals_value_clob is
     lob clob := 'long string value';
   begin
-    assertTrue(pljson_helper.equals(pljson_value(lob),lob), 'pljson_helper.equals(pljson_value(lob),lob)');
-    assertTrue(pljson_helper.equals(pljson_value('long string value'),lob), 'pljson_helper.equals(pljson_value(''long string value''),lob)');
-    assertFalse(pljson_helper.equals(pljson_value('not long string value'),lob), 'pljson_helper.equals(pljson_value(''not long string value''),lob)');
+    assertTrue(pljson_helper.equals(pljson_value(lob), lob), 'pljson_helper.equals(pljson_value(lob), lob)');
+    assertTrue(pljson_helper.equals(pljson_value('long string value'), lob), 'pljson_helper.equals(pljson_value(''long string value''), lob)');
+    assertFalse(pljson_helper.equals(pljson_value('not long string value'), lob), 'pljson_helper.equals(pljson_value(''not long string value''), lob)');
   end;
   
   -- equals(pljson, pljson)
   procedure test_equals_pljson_order is
   begin
-    assertTrue(pljson_helper.equals(pljson('{}'),pljson('{}')), 'pljson_helper.equals(pljson(''{}''),pljson(''{}''))');
-    assertTrue(pljson_helper.equals(pljson('{"a":1}'),pljson('{"a":1}')), 'pljson_helper.equals(pljson(''{"a":1}''),pljson(''{"a":1}''))');
-    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":{"b1":[1,2,3]}}'),pljson('{"a":1,"b":{"b1":[1,2,3]}}')), 'pljson_helper.equals(pljson(''{"a":1,"b":{"b1":[1,2,3]}}''),pljson(''{"a":1,"b":{"b1":[1,2,3]}}''))');
+    assertTrue(pljson_helper.equals(pljson('{}'), pljson('{}')), 'pljson_helper.equals(pljson(''{}''), pljson(''{}''))');
+    assertTrue(pljson_helper.equals(pljson('{"a":1}'), pljson('{"a":1}')), 'pljson_helper.equals(pljson(''{"a":1}''), pljson(''{"a":1}''))');
+    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":{"b1":[1,2,3]}}'), pljson('{"a":1,"b":{"b1":[1,2,3]}}')), 'pljson_helper.equals(pljson(''{"a":1,"b":{"b1":[1,2,3]}}''), pljson(''{"a":1,"b":{"b1":[1,2,3]}}''))');
   end;
   
   -- equals(pljson, pljson) - order does not matter
   procedure test_equals_pljson_no_order is
   begin
-    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}'),pljson('{"b":2,"a":1}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}''),pljson(''{"b":2,"a":1}''))');
+    assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}'), pljson('{"b":2,"a":1}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}''), pljson(''{"b":2,"a":1}''))');
   end;
   
   -- equals(pljson_list, pljson_list)
   procedure test_equals_list_list_order is
   begin
-    assertTrue(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,2,3]''))');
-    assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,2]''))');
+    assertTrue(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,2,3]''))');
+    assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,2]''))');
   end;
   
   -- equals(pljson_list, pljson_list) - order sensitive
   procedure test_equals_list_list_no_order is
   begin
-    assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,3,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,3,2]''))');
-    assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,3,2]'),true), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,3,2]''),true)');
+    assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,3,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,3,2]''))');
+    assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,3,2]'), true), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,3,2]''), true)');
   end;
   
   -- contains(pljson, pljson_value)
   procedure test_contains_value is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1,2]').to_json_value), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1,2]'').to_json_value)');
+    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1,2]').to_json_value), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1,2]'').to_json_value)');
   end;
   
   -- contains(pljson, pljson)
   procedure test_contains_pljson is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson('{"a":[1,2]}')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson(''{"a":[1,2]}''))');
+    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson('{"a":[1,2]}')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson(''{"a":[1,2]}''))');
   end;
   
   -- contains(pljson, pljson_list)
   procedure test_contains_list is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1,2]')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1,2]''))');
+    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1,2]')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1,2]''))');
   end;
   
   -- contains(pljson, pljson_list) - sublist match exact
   procedure test_contains_list_exact is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1]'),false), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1]''),false)');
-    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1]''),true)');
-    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[2]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[2]''),true)');
+    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1]'),false), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1]''),false)');
+    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1]''),true)');
+    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[2]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[2]''),true)');
   end;
   
   -- contains(pljson, number)
   procedure test_contains_number is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),3)');
-    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":4}'),3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":4}''),3)');
+    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), 3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), 3)');
+    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":4}'), 3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":4}''), 3)');
   end;
   
   -- contains(pljson, binary_double)
@@ -432,58 +432,58 @@ create or replace package body utplsql_pljson_helper_test is
   -- contains(pljson, varchar2)
   procedure test_contains_varchar2 is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"xyz"}'),'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"xyz"}''),''xyz'')');
-    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"wxyz"}'),'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"wxyz"}''),''xyz'')');
+    assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"xyz"}'), 'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"xyz"}''), ''xyz'')');
+    assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"wxyz"}'), 'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"wxyz"}''), ''xyz'')');
   end;
   
   -- contains(pljson, boolean)
   procedure test_contains_boolean is
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":true,"b":3}'),true), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''),true)');
-    assertFalse(pljson_helper.contains(pljson('{"a":true,"b":3}'),false), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''),false)');
+    assertTrue(pljson_helper.contains(pljson('{"a":true,"b":3}'), true), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''), true)');
+    assertFalse(pljson_helper.contains(pljson('{"a":true,"b":3}'), false), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''), false)');
   end;
   
   -- contains(pljson, clob)
   procedure test_contains_clob is
     lob clob := 'a long string';
   begin
-    assertTrue(pljson_helper.contains(pljson('{"a":1,"b":"a long string"}'),lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"a long string"}''),lob)');
-    assertFalse(pljson_helper.contains(pljson('{"a":1,"b":"not a long string"}'),lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"not a long string"}''),lob)');
+    assertTrue(pljson_helper.contains(pljson('{"a":1,"b":"a long string"}'), lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"a long string"}''), lob)');
+    assertFalse(pljson_helper.contains(pljson('{"a":1,"b":"not a long string"}'), lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"not a long string"}''), lob)');
   end;
   
   -- contains(pljson_list, pljson_value)
   procedure test_contains_list_value is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),pljson_value(3)), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),pljson_value(3))');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), pljson_value(3)), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), pljson_value(3))');
   end;
   
   -- contains(pljson_list, pljson)
   procedure test_contains_list_pljson is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),pljson('{"a":6}')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),pljson(''{"a":6}''))');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), pljson('{"a":6}')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), pljson(''{"a":6}''))');
   end;
   
   -- contains(pljson_list, pljson_list)
   procedure test_contains_list_list is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),pljson_list(''[4,5]''))');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,7],{"a":6}]'),pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,7],{"a":6}]''),pljson_list(''[4,5]''))');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), pljson_list(''[4,5]''))');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,7],{"a":6}]'), pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,7],{"a":6}]''), pljson_list(''[4,5]''))');
   end;
   
   -- contains(pljson_list, pljson_list) - sublist match exact
   procedure test_contains_list_list_exact is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[4,5]'),false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[4,5]''),false)');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[4,5]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[4,5]''),true)');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[5,4]'),false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[5,4]''),false)');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[5,4]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[5,4]''),true)');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[4,5]'), false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[4,5]''), false)');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[4,5]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[4,5]''), true)');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[5,4]'), false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[5,4]''), false)');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[5,4]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[5,4]''), true)');
   end;
   
   -- contains(pljson_list, number)
   procedure test_contains_list_number is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),3), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),3)');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,7,"xyz",[4,5],{"a":6}]'),3), 'pljson_helper.contains(pljson_list(''[1,2,7,"xyz",[4,5],{"a":6}]''),3)');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), 3), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), 3)');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,7,"xyz",[4,5],{"a":6}]'), 3), 'pljson_helper.contains(pljson_list(''[1,2,7,"xyz",[4,5],{"a":6}]''), 3)');
   end;
   
   -- contains(pljson_list, binary_double)
@@ -497,24 +497,25 @@ create or replace package body utplsql_pljson_helper_test is
   -- contains(pljson_list, varchar2)
   procedure test_contains_list_varchar2 is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),''xyz'')');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"wxyz",[4,5],{"a":6}]'),'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"wxyz",[4,5],{"a":6}]''),''xyz'')');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), 'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), ''xyz'')');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"wxyz",[4,5],{"a":6}]'), 'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"wxyz",[4,5],{"a":6}]''), ''xyz'')');
   end;
   
   -- contains(pljson_list, boolean)
   procedure test_contains_list_boolean is
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],true]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],true]''),true)');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],false]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],false]''),true)');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],true]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],true]''), true)');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],false]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],false]''), true)');
   end;
   
   -- contains(pljson_list, clob)
   procedure test_contains_list_clob is
     lob clob := 'a long string';
   begin
-    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"a long string",[4,5],{"a":6}]'),lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"a long string",[4,5],{"a":6}]''),lob)');
-    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"not a long string",[4,5],{"a":6}]'),lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"not a long string",[4,5],{"a":6}]''),lob)');
+    assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"a long string",[4,5],{"a":6}]'), lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"a long string",[4,5],{"a":6}]''), lob)');
+    assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"not a long string",[4,5],{"a":6}]'), lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"not a long string",[4,5],{"a":6}]''), lob)');
   end;
   
 end utplsql_pljson_helper_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_list_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_list_test.sql
@@ -43,6 +43,9 @@ create or replace package utplsql_pljson_list_test is
   --%test(Test get first and last)
   procedure test_get_first_last;
   
+  --%test(Test get tail)
+  procedure test_get_tail;
+  
   --%test(Test insert null number)
   procedure test_insert_null_number;
   
@@ -202,7 +205,7 @@ create or replace package body utplsql_pljson_list_test is
     /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
     l.append(2.718281828459e210d);
     l.append(pljson_value(false));
-    l.append(pljson_value.makenull);
+    l.append(pljson_value());
     l.append(pljson_list('[1,2,3]'));
     assertTrue(l.count = 6, 'l.count = 6');
     l.append(l.head);
@@ -327,6 +330,20 @@ create or replace package body utplsql_pljson_list_test is
     assertTrue(2 = n.get_number, '2 = n.get_number');
   end;
   
+  -- get tail
+  procedure test_get_tail is
+    l1 pljson_list;
+    l2 pljson_list;
+  begin
+    l1 := pljson_list('[1, "2", 3]');
+    l2 := l1.tail();
+    pljson_ut.assertTrue(strip_eol(l1.to_char) = '[1, "2", 3]', 'strip_eol(l1.to_char) = ''[1, "2", 3]''');
+    pljson_ut.assertTrue(strip_eol(l2.to_char) = '["2", 3]', 'strip_eol(l2.to_char) = ''["2", 3]''');
+    l2 := l2.tail();
+    pljson_ut.assertTrue(strip_eol(l1.to_char) = '[1, "2", 3]', 'strip_eol(l1.to_char) = ''[1, "2", 3]''');
+    pljson_ut.assertTrue(strip_eol(l2.to_char) = '[3]', 'strip_eol(l2.to_char) = ''[3]''');
+  end;
+  
   -- insert null number
   procedure test_insert_null_number is
     obj pljson_list := pljson_list();
@@ -410,3 +427,4 @@ create or replace package body utplsql_pljson_list_test is
   end;
 end utplsql_pljson_list_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_parser_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_parser_test.sql
@@ -296,3 +296,4 @@ create or replace package body utplsql_pljson_parser_test is
   
 end utplsql_pljson_parser_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_path_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_path_test.sql
@@ -209,7 +209,7 @@ create or replace package body utplsql_pljson_path_test is
   begin
     pljson_ext.put(obj, 'a', true);
     assertTrue(pljson_ext.get_json_value(obj, 'a').get_bool, 'pljson_ext.get_json_value(obj, ''a'').get_bool');
-    pljson_ext.put(obj, 'a', pljson_value.makenull);
+    pljson_ext.put(obj, 'a', pljson_value());
     assertTrue(pljson_ext.get_json_value(obj, 'a').is_null, 'pljson_ext.get_json_value(obj, ''a'').is_null');
     pljson_ext.put(obj, 'a', 'string');
     assertTrue(nvl(pljson_ext.get_string(obj, 'a'),'a') = 'string', 'nvl(pljson_ext.get_string(obj, ''a''),''a'') = ''string''');
@@ -350,3 +350,4 @@ create or replace package body utplsql_pljson_path_test is
   
 end utplsql_pljson_path_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_simple_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_simple_test.sql
@@ -228,3 +228,4 @@ create or replace package body utplsql_pljson_simple_test is
   
 end utplsql_pljson_simple_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_test.sql
@@ -285,7 +285,7 @@ create or replace package body utplsql_pljson_test is
         fail(test_name);
     end;
     begin
-      test_name := 'x1 := obj.get(''X2'').get_string;';
+      test_name := 'x2 := obj.get(''X2'').get_string;';
       x2 := obj.get('X2').get_string;
       pass(test_name);
     exception
@@ -353,3 +353,4 @@ create or replace package body utplsql_pljson_test is
   
 end utplsql_pljson_test;
 /
+show err

--- a/testsuite-utplsql/utplsql_pljson_unicode_test.sql
+++ b/testsuite-utplsql/utplsql_pljson_unicode_test.sql
@@ -318,3 +318,4 @@ begin
   
 end utplsql_pljson_unicode_test;
 /
+show err

--- a/testsuite/pljson.test.sql
+++ b/testsuite/pljson.test.sql
@@ -62,7 +62,8 @@ begin
   -- put method with position
   pljson_ut.testcase('Test put method with position');
   declare
-    obj pljson; tester varchar2(4000);
+    obj pljson;
+    tester varchar2(4000);
   begin
     obj := pljson();
     obj.put('A', 'A', 1);
@@ -209,7 +210,7 @@ begin
         pljson_ut.fail(test_name);
     end;
     begin
-      test_name := 'x1 := obj.get(''X2'').get_string;';
+      test_name := 'x2 := obj.get(''X2'').get_string;';
       x2 := obj.get('X2').get_string;
       pljson_ut.pass(test_name);
     exception
@@ -263,7 +264,7 @@ begin
   begin
     obj.put('X', x);
     n := obj.get('X');
-    pljson_ut.assertFalse(n is null, 'n is null'); --may seem odd -- but initialized vars are best
+    pljson_ut.assertFalse(n is null, 'n is null'); --may seem odd -- but initialized vars are best!
   end;
   
   -- insert null pair name

--- a/testsuite/pljson_base64.test.sql
+++ b/testsuite/pljson_base64.test.sql
@@ -10,7 +10,7 @@ set serveroutput on format wrapped
 set linesize 66
 
 declare
-  procedure base64_check(w_clob in out clob) is
+  procedure base64_check(w_clob in clob) is
     obj_json pljson;
     tmp_json pljson;
     w_json_tag varchar2(32) := 'binaryFile';
@@ -19,6 +19,7 @@ declare
     w_hash1 varchar2(40);
     w_hash2 varchar2(40);
     
+    w_clob_new clob;
     w_clob1 clob;
     w_clob2 clob;
     w_char varchar2(1000);
@@ -65,30 +66,29 @@ declare
     dbms_output.put_line('---------------------------------------------------------------');
     
     --dbms_lob.createtemporary(w_clob, true);
-    dbms_lob.trim(w_clob, 0);
+    --dbms_lob.trim(w_clob, 0);
     
     -- JSON creation/parsing  
     obj_json := new pljson();
     obj_json.put(w_json_tag, pljson_ext.encode(w_blob));
     obj_value := pljson_ext.get_json_value(obj_json, w_json_tag);
-    --pljson_value.get_string(obj_value, w_clob);
-    obj_value.get_string(w_clob);
+    w_clob_new := obj_value.get_clob();
     
     /* debugging
     dbms_output.put_line('c2>>');
-    dbms_output.put_line(dbms_lob.substr(w_clob, 200, 1));
+    dbms_output.put_line(dbms_lob.substr(w_clob_new, 200, 1));
     dbms_output.put_line('===');
-    dbms_output.put_line(dbms_lob.substr(w_clob, 200, dbms_lob.getlength(w_clob) - 199));
+    dbms_output.put_line(dbms_lob.substr(w_clob_new, 200, dbms_lob.getlength(w_clob_new) - 199));
     dbms_output.put_line('<<c2');
-    dbms_lob.copy(w_clob2, w_clob, 2000000);
+    dbms_lob.copy(w_clob2, w_clob_new, 2000000);
     
-    select dump(dbms_lob.substr(w_clob, 150, 1), 16)
+    select dump(dbms_lob.substr(w_clob_new, 150, 1), 16)
     into w_char
     from dual;
     dbms_output.put_line('c2(dump)>>' || w_char || '<<c2(dump)');
     */
     
-    w_blob := pljson_ext.decode(new pljson_value(w_clob));
+    w_blob := pljson_ext.decode(new pljson_value(w_clob_new));
     
     /* debugging
     dbms_output.put_line('b2>>' || dbms_lob.substr(w_blob, 200, 1));

--- a/testsuite/pljson_helper.test.sql
+++ b/testsuite/pljson_helper.test.sql
@@ -42,7 +42,7 @@ begin
   declare
     obj pljson;
   begin
-    obj := pljson_helper.merge(pljson('{"a":1,"b":"str","c":{}}'),pljson('{"d":2,"e":"x"}'));
+    obj := pljson_helper.merge(pljson('{"a":1,"b":"str","c":{}}'), pljson('{"d":2,"e":"x"}'));
     pljson_ut.assertTrue(obj.count = 5, 'obj.count = 5');
     pljson_ut.assertTrue(strip_eol(obj.to_char(false)) = '{"a":1,"b":"str","c":{},"d":2,"e":"x"}', 'strip_eol(obj.to_char(false)) = ''{"a":1,"b":"str","c":{},"d":2,"e":"x"}''');
   end;
@@ -52,7 +52,7 @@ begin
   declare
     obj pljson;
   begin
-    obj := pljson_helper.merge(pljson('{"a":1,"b":"x"}'),pljson('{"a":2,"c":"y"}'));
+    obj := pljson_helper.merge(pljson('{"a":1,"b":"x"}'), pljson('{"a":2,"c":"y"}'));
     pljson_ut.assertTrue(obj.count = 3, 'obj.count = 3');
     pljson_ut.assertTrue(obj.get('a').get_number = 2, 'obj.get(''a'').get_number = 2');
   end;
@@ -63,7 +63,7 @@ begin
     obj pljson;
     val pljson_value;
   begin
-    obj := pljson_helper.merge(pljson('{"a":{"a1":1,"a2":{}}}'),pljson('{"a":{"a2":{"a2a":1},"a3":2}}'));
+    obj := pljson_helper.merge(pljson('{"a":{"a1":1,"a2":{}}}'), pljson('{"a":{"a2":{"a2a":1},"a3":2}}'));
     val := obj.get('a');
     pljson_ut.assertTrue(pljson(val).count = 3, 'pljson(val).count = 3');
     pljson_ut.assertTrue(val.to_char(false) = '{"a1":1,"a2":{"a2a":1},"a3":2}', 'val.to_char(false) = ''{"a1":1,"a2":{"a2a":1},"a3":2}''');
@@ -74,7 +74,7 @@ begin
   declare
     obj pljson_list;
   begin
-    obj := pljson_helper.join(pljson_list('[]'),pljson_list('[]'));
+    obj := pljson_helper.join(pljson_list('[]'), pljson_list('[]'));
     pljson_ut.assertTrue(obj.count = 0, 'obj.count = 0');
   end;
   
@@ -83,7 +83,7 @@ begin
   declare
     obj pljson_list;
   begin
-    obj := pljson_helper.join(pljson_list('[1,2,3]'),pljson_list('[4,5,6]'));
+    obj := pljson_helper.join(pljson_list('[1,2,3]'), pljson_list('[4,5,6]'));
     pljson_ut.assertTrue(obj.count = 6, 'obj.count = 6');
     pljson_ut.assertTrue(obj.to_char(false) = '[1,2,3,4,5,6]', 'obj.to_char(false) = ''[1,2,3,4,5,6]''');
   end;
@@ -93,7 +93,7 @@ begin
   declare
     obj pljson_list;
   begin
-    obj := pljson_helper.join(pljson_list('[1,"2",{"a":1}]'),pljson_list('[3,"4",{"b":2}]'));
+    obj := pljson_helper.join(pljson_list('[1,"2",{"a":1}]'), pljson_list('[3,"4",{"b":2}]'));
     pljson_ut.assertTrue(obj.count = 6, 'obj.count = 6');
     pljson_ut.assertTrue(strip_eol(obj.to_char(false)) = '[1,"2",{"a":1},3,"4",{"b":2}]', 'strip_eol(obj.to_char(false)) = ''[1,"2",{"a":1},3,"4",{"b":2}]''');
   end;
@@ -103,7 +103,7 @@ begin
   declare
     obj pljson;
   begin
-    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":{}}'),pljson_list('[]'));
+    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":{}}'), pljson_list('[]'));
     pljson_ut.assertTrue(obj.count = 0, 'obj.count = 0');
     pljson_ut.assertTrue(obj.to_char(false) = '{}', 'obj.to_char(false) = ''{}''');
   end;
@@ -113,7 +113,7 @@ begin
   declare
     obj pljson;
   begin
-    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":3}'),pljson_list('["a","c"]'));
+    obj := pljson_helper.keep(pljson('{"a":1,"b":2,"c":3}'), pljson_list('["a","c"]'));
     pljson_ut.assertTrue(obj.count = 2, 'obj.count = 2');
     pljson_ut.assertTrue(obj.to_char(false) = '{"a":1,"c":3}', 'obj.to_char(false) = ''{"a":1,"c":3}''');
   end;
@@ -123,7 +123,7 @@ begin
   declare
     obj pljson;
   begin
-    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'),pljson_list('[]'));
+    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'), pljson_list('[]'));
     pljson_ut.assertTrue(obj.count = 3, 'obj.count = 3');
     pljson_ut.assertTrue(obj.to_char(false) = '{"a":1,"b":2,"c":3}', 'obj.to_char(false) = ''{"a":1,"b":2,"c":3}''');
   end;
@@ -133,7 +133,7 @@ begin
   declare
     obj pljson;
   begin
-    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'),pljson_list('["a","c"]'));
+    obj := pljson_helper.remove(pljson('{"a":1,"b":2,"c":3}'), pljson_list('["a","c"]'));
     pljson_ut.assertTrue(obj.count = 1, 'obj.count = 1');
     pljson_ut.assertTrue(obj.get('b').get_number = 2, 'obj.get(''b'').get_number = 2');
   end;
@@ -141,32 +141,32 @@ begin
   -- equals(pljson_value, pljson_value)
   pljson_ut.testcase('Test equals(pljson_value, pljson_value)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(''),pljson_value('')), 'pljson_helper.equals(pljson_value(''''),pljson_value(''''))');
-    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value,pljson('{"a":1,"b":2}').to_json_value), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value,pljson(''{"a":1,"b":2}'').to_json_value)');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(''), pljson_value('')), 'pljson_helper.equals(pljson_value(''''), pljson_value(''''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value, pljson('{"a":1,"b":2}').to_json_value), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value, pljson(''{"a":1,"b":2}'').to_json_value)');
   end;
   
   -- equals(pljson_value, pljson_value) - empty constructor
   pljson_ut.testcase('Test equals(pljson_value, pljson_value) - empty constructor');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(),pljson_value()), 'pljson_helper.equals(pljson_value(),pljson_value())');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(), pljson_value()), 'pljson_helper.equals(pljson_value(), pljson_value())');
   end;
   
   -- equals(pljson_value, pljson)
   pljson_ut.testcase('Test equals(pljson_value, pljson)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value,pljson('{"a":1,"b":2}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value,pljson(''{"a":1,"b":2}''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}').to_json_value, pljson('{"a":1,"b":2}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}'').to_json_value, pljson(''{"a":1,"b":2}''))');
   end;
   
   -- equals(pljson_value, pljson_list)
   pljson_ut.testcase('Test equals(pljson_value, pljson_list)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_list('[1,2,3]').to_json_value,pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]'').to_json_value,pljson_list(''[1,2,3]''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_list('[1,2,3]').to_json_value, pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]'').to_json_value, pljson_list(''[1,2,3]''))');
   end;
   
   -- equals(pljson_value, number)
   pljson_ut.testcase('Test equals(pljson_value, number)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(2),2), 'pljson_helper.equals(pljson_value(2),2)');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(2), 2), 'pljson_helper.equals(pljson_value(2), 2)');
   end;
   
   -- equals(pljson_value, binary_double)
@@ -179,20 +179,20 @@ begin
   -- equals(pljson_value, varchar2)
   pljson_ut.testcase('Test equals(pljson_value, varchar2)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value('xyz'),'xyz'), 'pljson_helper.equals(pljson_value(''xyz''),''xyz'')');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value('xyz'), 'xyz'), 'pljson_helper.equals(pljson_value(''xyz''), ''xyz'')');
   end;
   
   -- equals(pljson_value, varchar2) - empty string value
   pljson_ut.testcase('Test equals(pljson_value, varchar2) - empty string value');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(''),''), 'pljson_helper.equals(pljson_value(''''),'''')');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(''), ''), 'pljson_helper.equals(pljson_value(''''), '''')');
   end;
   
   -- equals(pljson_value, boolean)
   pljson_ut.testcase('Test equals(pljson_value, boolean)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(true),true), 'pljson_helper.equals(pljson_value(true),true)');
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(false),false), 'pljson_helper.equals(pljson_value(false),false)');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(true), true), 'pljson_helper.equals(pljson_value(true), true)');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(false), false), 'pljson_helper.equals(pljson_value(false), false)');
   end;
   
   -- equals(pljson_value, clob)
@@ -200,70 +200,70 @@ begin
   declare
     lob clob := 'long string value';
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(lob),lob), 'pljson_helper.equals(pljson_value(lob),lob)');
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_value('long string value'),lob), 'pljson_helper.equals(pljson_value(''long string value''),lob)');
-    pljson_ut.assertFalse(pljson_helper.equals(pljson_value('not long string value'),lob), 'pljson_helper.equals(pljson_value(''not long string value''),lob)');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value(lob), lob), 'pljson_helper.equals(pljson_value(lob), lob)');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_value('long string value'), lob), 'pljson_helper.equals(pljson_value(''long string value''), lob)');
+    pljson_ut.assertFalse(pljson_helper.equals(pljson_value('not long string value'), lob), 'pljson_helper.equals(pljson_value(''not long string value''), lob)');
   end;
   
   -- equals(pljson, pljson)
   pljson_ut.testcase('Test equals(pljson, pljson)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson('{}'),pljson('{}')), 'pljson_helper.equals(pljson(''{}''),pljson(''{}''))');
-    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1}'),pljson('{"a":1}')), 'pljson_helper.equals(pljson(''{"a":1}''),pljson(''{"a":1}''))');
-    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":{"b1":[1,2,3]}}'),pljson('{"a":1,"b":{"b1":[1,2,3]}}')), 'pljson_helper.equals(pljson(''{"a":1,"b":{"b1":[1,2,3]}}''),pljson(''{"a":1,"b":{"b1":[1,2,3]}}''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson('{}'), pljson('{}')), 'pljson_helper.equals(pljson(''{}''), pljson(''{}''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1}'), pljson('{"a":1}')), 'pljson_helper.equals(pljson(''{"a":1}''), pljson(''{"a":1}''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":{"b1":[1,2,3]}}'), pljson('{"a":1,"b":{"b1":[1,2,3]}}')), 'pljson_helper.equals(pljson(''{"a":1,"b":{"b1":[1,2,3]}}''), pljson(''{"a":1,"b":{"b1":[1,2,3]}}''))');
   end;
   
   -- equals(pljson, pljson) - order does not matter
   pljson_ut.testcase('Test equals(pljson, pljson) - order does not matter');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}'),pljson('{"b":2,"a":1}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}''),pljson(''{"b":2,"a":1}''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson('{"a":1,"b":2}'), pljson('{"b":2,"a":1}')), 'pljson_helper.equals(pljson(''{"a":1,"b":2}''), pljson(''{"b":2,"a":1}''))');
   end;
   
   -- equals(pljson_list, pljson_list)
   pljson_ut.testcase('Test equals(pljson_list, pljson_list)');
   begin
-    pljson_ut.assertTrue(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,2,3]''))');
-    pljson_ut.assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,2]''))');
+    pljson_ut.assertTrue(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,2,3]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,2,3]''))');
+    pljson_ut.assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,2]''))');
   end;
   
   -- equals(pljson_list, pljson_list) - order sensitive
   pljson_ut.testcase('Test equals(pljson_list, pljson_list) - order sensitive');
   begin
-    pljson_ut.assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,3,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,3,2]''))');
-    pljson_ut.assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'),pljson_list('[1,3,2]'),true), 'pljson_helper.equals(pljson_list(''[1,2,3]''),pljson_list(''[1,3,2]''),true)');
+    pljson_ut.assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,3,2]')), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,3,2]''))');
+    pljson_ut.assertFalse(pljson_helper.equals(pljson_list('[1,2,3]'), pljson_list('[1,3,2]'), true), 'pljson_helper.equals(pljson_list(''[1,2,3]''), pljson_list(''[1,3,2]''), true)');
   end;
   
   -- contains(pljson, pljson_value)
   pljson_ut.testcase('Test contains(pljson, pljson_value)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1,2]').to_json_value), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1,2]'').to_json_value)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1,2]').to_json_value), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1,2]'').to_json_value)');
   end;
   
   -- contains(pljson, pljson)
   pljson_ut.testcase('Test contains(pljson, pljson)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson('{"a":[1,2]}')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson(''{"a":[1,2]}''))');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson('{"a":[1,2]}')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson(''{"a":[1,2]}''))');
   end;
   
   -- contains(pljson, pljson_list)
   pljson_ut.testcase('Test contains(pljson, pljson_list)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1,2]')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1,2]''))');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1,2]')), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1,2]''))');
   end;
   
   -- contains(pljson, pljson_list) - sublist match exact
   pljson_ut.testcase('Test contains(pljson, pljson_list) - sublist match exact');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1]'),false), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1]''),false)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[1]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[1]''),true)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),pljson_list('[2]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),pljson_list(''[2]''),true)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1]'),false), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1]''),false)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[1]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[1]''),true)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), pljson_list('[2]'),true), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), pljson_list(''[2]''),true)');
   end;
   
   -- contains(pljson, number)
   pljson_ut.testcase('Test contains(pljson, number)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'),3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''),3)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":4}'),3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":4}''),3)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3}'), 3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3}''), 3)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":4}'), 3), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":4}''), 3)');
   end;
   
   -- contains(pljson, binary_double)
@@ -277,15 +277,15 @@ begin
   -- contains(pljson, varchar2)
   pljson_ut.testcase('Test contains(pljson, varchar2)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"xyz"}'),'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"xyz"}''),''xyz'')');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"wxyz"}'),'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"wxyz"}''),''xyz'')');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"xyz"}'), 'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"xyz"}''), ''xyz'')');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":[1,2],"b":3,"c":"wxyz"}'), 'xyz'), 'pljson_helper.contains(pljson(''{"a":[1,2],"b":3,"c":"wxyz"}''), ''xyz'')');
   end;
   
   -- contains(pljson, boolean)
   pljson_ut.testcase('Test contains(pljson, boolean)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":true,"b":3}'),true), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''),true)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":true,"b":3}'),false), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''),false)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":true,"b":3}'), true), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''), true)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":true,"b":3}'), false), 'pljson_helper.contains(pljson(''{"a":true,"b":3}''), false)');
   end;
   
   -- contains(pljson, clob)
@@ -293,43 +293,43 @@ begin
   declare
     lob clob := 'a long string';
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":1,"b":"a long string"}'),lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"a long string"}''),lob)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":1,"b":"not a long string"}'),lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"not a long string"}''),lob)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson('{"a":1,"b":"a long string"}'), lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"a long string"}''), lob)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson('{"a":1,"b":"not a long string"}'), lob), 'pljson_helper.contains(pljson(''{"a":1,"b":"not a long string"}''), lob)');
   end;
   
   -- contains(pljson_list, pljson_value)
   pljson_ut.testcase('Test contains(pljson_list, pljson_value)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),pljson_value(3)), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),pljson_value(3))');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), pljson_value(3)), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), pljson_value(3))');
   end;
   
   -- contains(pljson_list, pljson)
   pljson_ut.testcase('Test contains(pljson_list, pljson)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),pljson('{"a":6}')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),pljson(''{"a":6}''))');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), pljson('{"a":6}')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), pljson(''{"a":6}''))');
   end;
   
   -- contains(pljson_list, pljson_list)
   pljson_ut.testcase('Test contains(pljson_list, pljson_list)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),pljson_list(''[4,5]''))');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,7],{"a":6}]'),pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,7],{"a":6}]''),pljson_list(''[4,5]''))');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), pljson_list(''[4,5]''))');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,7],{"a":6}]'), pljson_list('[4,5]')), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,7],{"a":6}]''), pljson_list(''[4,5]''))');
   end;
   
   -- contains(pljson_list, pljson_list) - sublist match exact
   pljson_ut.testcase('Test contains(pljson_list, pljson_list) - sublist match exact');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[4,5]'),false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[4,5]''),false)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[4,5]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[4,5]''),true)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[5,4]'),false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[5,4]''),false)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'),pljson_list('[5,4]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''),pljson_list(''[5,4]''),true)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[4,5]'), false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[4,5]''), false)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[4,5]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[4,5]''), true)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[5,4]'), false), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[5,4]''), false)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,[4,5,7]]'), pljson_list('[5,4]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,[4,5,7]]''), pljson_list(''[5,4]''), true)');
   end;
   
   -- contains(pljson_list, number)
   pljson_ut.testcase('Test contains(pljson_list, number)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),3), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),3)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,7,"xyz",[4,5],{"a":6}]'),3), 'pljson_helper.contains(pljson_list(''[1,2,7,"xyz",[4,5],{"a":6}]''),3)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), 3), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), 3)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,7,"xyz",[4,5],{"a":6}]'), 3), 'pljson_helper.contains(pljson_list(''[1,2,7,"xyz",[4,5],{"a":6}]''), 3)');
   end;
   
   -- contains(pljson_list, binary_double)
@@ -343,15 +343,15 @@ begin
   -- contains(pljson_list, varchar2)
   pljson_ut.testcase('Test contains(pljson_list, varchar2)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'),'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''),''xyz'')');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"wxyz",[4,5],{"a":6}]'),'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"wxyz",[4,5],{"a":6}]''),''xyz'')');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],{"a":6}]'), 'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],{"a":6}]''), ''xyz'')');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"wxyz",[4,5],{"a":6}]'), 'xyz'), 'pljson_helper.contains(pljson_list(''[1,2,3,"wxyz",[4,5],{"a":6}]''), ''xyz'')');
   end;
   
   -- contains(pljson_list, boolean)
   pljson_ut.testcase('Test contains(pljson_list, boolean)');
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],true]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],true]''),true)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],false]'),true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],false]''),true)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],true]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],true]''), true)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"xyz",[4,5],false]'), true), 'pljson_helper.contains(pljson_list(''[1,2,3,"xyz",[4,5],false]''), true)');
   end;
   
   -- contains(pljson_list, clob)
@@ -359,8 +359,8 @@ begin
   declare
     lob clob := 'a long string';
   begin
-    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"a long string",[4,5],{"a":6}]'),lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"a long string",[4,5],{"a":6}]''),lob)');
-    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"not a long string",[4,5],{"a":6}]'),lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"not a long string",[4,5],{"a":6}]''),lob)');
+    pljson_ut.assertTrue(pljson_helper.contains(pljson_list('[1,2,3,"a long string",[4,5],{"a":6}]'), lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"a long string",[4,5],{"a":6}]''), lob)');
+    pljson_ut.assertFalse(pljson_helper.contains(pljson_list('[1,2,3,"not a long string",[4,5],{"a":6}]'), lob), 'pljson_helper.contains(pljson_list(''[1,2,3,"not a long string",[4,5],{"a":6}]''), lob)');
   end;
   
   pljson_ut.testsuite_report;

--- a/testsuite/pljson_list.test.sql
+++ b/testsuite/pljson_list.test.sql
@@ -114,7 +114,7 @@ begin
     /* E.I.Sarmas (github.com/dsnz)   2016-12-01   support for binary_double numbers */
     l.append(2.718281828459e210d);
     l.append(pljson_value(false));
-    l.append(pljson_value.makenull);
+    l.append(pljson_value());
     l.append(pljson_list('[1,2,3]'));
     pljson_ut.assertTrue(l.count = 6, 'l.count = 6');
     l.append(l.head);
@@ -243,6 +243,21 @@ begin
     pljson_ut.assertTrue(1 = n.get_number, '1 = n.get_number');
     n := l.last;
     pljson_ut.assertTrue(2 = n.get_number, '2 = n.get_number');
+  end;
+  
+  -- get tail
+  pljson_ut.testcase('Test get tail');
+  declare
+    l1 pljson_list;
+    l2 pljson_list;
+  begin
+    l1 := pljson_list('[1, "2", 3]');
+    l2 := l1.tail();
+    pljson_ut.assertTrue(strip_eol(l1.to_char) = '[1, "2", 3]', 'strip_eol(l1.to_char) = ''[1, "2", 3]''');
+    pljson_ut.assertTrue(strip_eol(l2.to_char) = '["2", 3]', 'strip_eol(l2.to_char) = ''["2", 3]''');
+    l2 := l2.tail();
+    pljson_ut.assertTrue(strip_eol(l1.to_char) = '[1, "2", 3]', 'strip_eol(l1.to_char) = ''[1, "2", 3]''');
+    pljson_ut.assertTrue(strip_eol(l2.to_char) = '[3]', 'strip_eol(l2.to_char) = ''[3]''');
   end;
   
   -- insert null number

--- a/testsuite/pljson_parser.test.sql
+++ b/testsuite/pljson_parser.test.sql
@@ -179,7 +179,8 @@ begin
     dbms_lob.freetemporary(test_clob);
     pljson_ut.pass(test_name);
   exception
-    when others then pljson_ut.fail(test_name);
+    when others then
+      pljson_ut.fail(test_name);
   end;
   
   pljson_ut.testsuite_report;

--- a/testsuite/pljson_path.test.sql
+++ b/testsuite/pljson_path.test.sql
@@ -133,7 +133,7 @@ begin
   begin
     pljson_ext.put(obj, 'a', true);
     pljson_ut.assertTrue(pljson_ext.get_json_value(obj, 'a').get_bool, 'pljson_ext.get_json_value(obj, ''a'').get_bool');
-    pljson_ext.put(obj, 'a', pljson_value.makenull);
+    pljson_ext.put(obj, 'a', pljson_value());
     pljson_ut.assertTrue(pljson_ext.get_json_value(obj, 'a').is_null, 'pljson_ext.get_json_value(obj, ''a'').is_null');
     pljson_ext.put(obj, 'a', 'string');
     pljson_ut.assertTrue(nvl(pljson_ext.get_string(obj, 'a'),'a') = 'string', 'nvl(pljson_ext.get_string(obj, ''a''),''a'') = ''string''');

--- a/uninstall.sql
+++ b/uninstall.sql
@@ -64,10 +64,7 @@ declare begin
   begin execute immediate 'drop package pljson_ut'; exception when others then null; end;
   begin execute immediate 'drop table pljson_testsuite'; exception when others then null; end;
   
-  begin execute immediate 'drop public synonym pljson_element'; exception when others then null; end;
-  begin execute immediate 'drop public synonym pljson_narray'; exception when others then null; end;
-  begin execute immediate 'drop public synonym pljson_vtab'; exception when others then null; end;
-  begin execute immediate 'drop public synonym pljson_varray'; exception when others then null; end;
+  begin execute immediate 'drop synonym pljson_table'; exception when others then null; end;
   
   begin execute immediate 'drop public synonym pljson_parser'; exception when others then null; end;
   begin execute immediate 'drop public synonym pljson_printer'; exception when others then null; end;
@@ -82,9 +79,12 @@ declare begin
   begin execute immediate 'drop public synonym pljson_list'; exception when others then null; end;
   begin execute immediate 'drop public synonym pljson_value_array'; exception when others then null; end;
   begin execute immediate 'drop public synonym pljson_value'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_element'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_narray'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_vtab'; exception when others then null; end;
+  begin execute immediate 'drop public synonym pljson_varray'; exception when others then null; end;
   begin execute immediate 'drop public synonym pljson_table_impl'; exception when others then null; end;
   begin execute immediate 'drop public synonym pljson_table'; exception when others then null; end;
-  
   begin execute immediate 'drop public synonym pljson_ut'; exception when others then null; end;
   begin execute immediate 'drop public synonym pljson_testsuite'; exception when others then null; end;
   
@@ -103,7 +103,6 @@ declare begin
   begin execute immediate 'drop public synonym json_value'; exception when others then null; end;
   begin execute immediate 'drop public synonym json_table'; exception when others then null; end;
   
-  begin execute immediate 'drop synonym pljson_table'; exception when others then null; end;
   begin execute immediate 'drop synonym json_parser'; exception when others then null; end;
   begin execute immediate 'drop synonym json_printer'; exception when others then null; end;
   begin execute immediate 'drop synonym json_ext'; exception when others then null; end;
@@ -120,3 +119,4 @@ declare begin
   begin execute immediate 'drop synonym json_table'; exception when others then null; end;
 end;
 /
+show err


### PR DESCRIPTION
- new api calls that match those of version 3.0
(mainly get_string(), get_clob(), get_...() by pair_name for json objects and by position for json arrays)
- minor code rewrite so code is cleaner, conforms better to today's accepted code standards and
there is as much common code as possible between version 2.0 and version 3.0