### PR TITLE
fix for parsing json containing unicode chars of 4 bytes (e.g. emojis)

### DIFF
--- a/src/pljson_parser.decl.sql
+++ b/src/pljson_parser.decl.sql
@@ -33,7 +33,7 @@ create or replace package pljson_parser as
     data_overflow clob); -- max_string_size
 
   type lTokens is table of rToken index by pls_integer;
-  type json_src is record (len number, offset number, src varchar2(32767), s_clob clob);
+  type json_src is record (len number, offset number, offset_chars number, src varchar2(32767), s_clob clob);
 
   json_strict boolean not null := false;
 

--- a/testsuite/pljson_parser.test.sql
+++ b/testsuite/pljson_parser.test.sql
@@ -173,11 +173,15 @@ begin
     for i in reverse 3995..4005 loop
       --dbms_output.put_line('issue #37: ' || i || ' ' ||
       --  substr(test_buff, i-3995+1, 1) || ' - ' || pljson_parser.next_char(i, src));
-      pljson_ut.assertTrue(substr(test_buff, i-3995+1, 1) = pljson_parser.next_char(i, src));
+      pljson_ut.assertTrue(substr(test_buff, i-3995+1, 1) = pljson_parser.next_char(i, src), to_char(i-3995+1));
     end loop;
     
     dbms_lob.freetemporary(test_clob);
-    pljson_ut.pass(test_name);
+    if pljson_ut.case_fail = 0 then
+      pljson_ut.pass(test_name);
+    else
+      pljson_ut.fail(test_name);
+    end if;
   exception
     when others then
       pljson_ut.fail(test_name);


### PR DESCRIPTION
because of the way characters are stored in clob(s) and
how the dbms_lob api returns length and uses character indexes