### PR TITLE
fix for parsing json containing unicode chars of 4 bytes (e.g. emojis)

### DIFF
--- a/src/pljson_parser.decl.sql
+++ b/src/pljson_parser.decl.sql
@@ -33,7 +33,7 @@ create or replace package pljson_parser as
     data_overflow clob); -- max_string_size
 
   type lTokens is table of rToken index by pls_integer;
-  type json_src is record (len number, offset number, src varchar2(32767), s_clob clob);
+  type json_src is record (len number, offset number, offset_chars number, src varchar2(32767), s_clob clob);
 
   json_strict boolean not null := false;
 


### PR DESCRIPTION
fix for parsing json containing unicode chars of 4 bytes (e.g. emojis)
carried over from version 2.0