### PR TITLE
Pre-parsed path put/remove and performance improvements

### DIFF
--- a/src/pljson.type.decl.sql
+++ b/src/pljson.type.decl.sql
@@ -93,7 +93,9 @@ create or replace type pljson force under pljson_element (
 
   /* map functions */
   member function get_keys return pljson_list,
-  member function get_values return pljson_list
+  member function get_values return pljson_list,
+
+  overriding member function internal_path_put(self in out nocopy pljson, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
 ) not final;
 /
 show err

--- a/src/pljson.type.decl.sql
+++ b/src/pljson.type.decl.sql
@@ -95,7 +95,8 @@ create or replace type pljson force under pljson_element (
   member function get_keys return pljson_list,
   member function get_values return pljson_list,
 
-  overriding member function internal_path_put(self in out nocopy pljson, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
+  /** Private method for internal processing. */
+  overriding member function put_internal_path(self in out nocopy pljson, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
 ) not final;
 /
 show err

--- a/src/pljson.type.impl.sql
+++ b/src/pljson.type.impl.sql
@@ -470,7 +470,8 @@ create or replace type body pljson as
     return vals;
   end;
 
-  overriding member function internal_path_put(self in out nocopy pljson, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
+  /** Private method for internal processing. */
+  overriding member function put_internal_path(self in out nocopy pljson, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
     indx pls_integer;
     keystring varchar2(4000);
     new_obj pljson;
@@ -514,7 +515,7 @@ create or replace type body pljson as
             end if;
           end if;
 
-          if (self.json_data(indx).internal_path_put(path, elem, path_position + 1)) then
+          if (self.json_data(indx).put_internal_path(path, elem, path_position + 1)) then
             self.remove(keystring);
             return true;
           end if;
@@ -539,11 +540,11 @@ create or replace type body pljson as
       else
         if (path(path_position + 1).indx is null) then
           new_obj := pljson();
-          ret := new_obj.internal_path_put(path, elem, path_position + 1);
+          ret := new_obj.put_internal_path(path, elem, path_position + 1);
           put(keystring, new_obj);
         else
           new_list := pljson_list();
-          ret := new_list.internal_path_put(path, elem, path_position + 1);
+          ret := new_list.put_internal_path(path, elem, path_position + 1);
           put(keystring, new_list);
         end if;
       end if;

--- a/src/pljson.type.impl.sql
+++ b/src/pljson.type.impl.sql
@@ -469,6 +469,88 @@ create or replace type body pljson as
     vals.list_data := self.json_data;
     return vals;
   end;
+
+  overriding member function internal_path_put(self in out nocopy pljson, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
+    indx pls_integer;
+    keystring varchar2(4000);
+    new_obj pljson;
+    new_list pljson_list;
+    ret boolean := false;
+  begin
+    if (path(path_position).indx is null) then
+      keystring := path(path_position).name;
+    else
+      if (path(path_position).indx > self.json_data.count) then
+        if (elem is null) then
+          return false;
+        end if;
+        raise_application_error(-20110, 'PLJSON_EXT put error: access object with too few members.');
+      end if;
+
+      keystring := self.json_data(path(path_position).indx).mapname;
+    end if;
+
+    indx := self.json_data.first;
+    loop
+      exit when indx is null;
+
+      if ((keystring is null and self.json_data(indx).mapname is null) or (self.json_data(indx).mapname = keystring)) then
+        if (path_position < path.count) then
+          if (path(path_position + 1).indx is null) then
+            if (not self.json_data(indx).is_object()) then
+              if (elem is not null) then
+                put(keystring, pljson());
+              else
+                return false;
+              end if;
+            end if;
+          else
+            if (not self.json_data(indx).is_object() and not self.json_data(indx).is_array()) then
+              if (elem is not null) then
+                put(keystring, pljson_list());
+              else
+                return false;
+              end if;
+            end if;
+          end if;
+
+          if (self.json_data(indx).internal_path_put(path, elem, path_position + 1)) then
+            self.remove(keystring);
+            return true;
+          end if;
+        else
+          if (elem is null) then
+            self.remove(keystring);
+            return true;
+          else
+            self.put(keystring, elem);
+          end if;
+        end if;
+
+        return false;
+      end if;
+
+      indx := self.json_data.next(indx);
+    end loop;
+
+    if (elem is not null) then
+      if (path_position = path.count) then
+        put(keystring, elem);
+      else
+        if (path(path_position + 1).indx is null) then
+          new_obj := pljson();
+          ret := new_obj.internal_path_put(path, elem, path_position + 1);
+          put(keystring, new_obj);
+        else
+          new_list := pljson_list();
+          ret := new_list.internal_path_put(path, elem, path_position + 1);
+          put(keystring, new_list);
+        end if;
+      end if;
+    end if;
+
+    return ret;
+  end;
 end;
 /
 show err

--- a/src/pljson_element.type.decl.sql
+++ b/src/pljson_element.type.decl.sql
@@ -1,3 +1,12 @@
+create or replace type pljson_path_segment as object (
+  indx number(32),
+  name varchar2(4000)
+) final
+/
+
+create or replace type pljson_path as table of pljson_path_segment
+/
+
 create or replace type pljson_element force as object
 (
   /* 1 = object, 2 = array, 3 = string, 4 = number, 5 = bool, 6 = null */
@@ -46,7 +55,9 @@ create or replace type pljson_element force as object
   member function to_char(spaces boolean default true, chars_per_line number default 0) return varchar2,
   member procedure to_clob(self in pljson_element, buf in out nocopy clob, spaces boolean default false, chars_per_line number default 0, erase_clob boolean default true),
   member procedure print(self in pljson_element, spaces boolean default true, chars_per_line number default 8192, jsonp varchar2 default null),
-  member procedure htp(self in pljson_element, spaces boolean default false, chars_per_line number default 0, jsonp varchar2 default null)
+  member procedure htp(self in pljson_element, spaces boolean default false, chars_per_line number default 0, jsonp varchar2 default null),
+
+  member function internal_path_put(self in out nocopy pljson_element, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
 ) not final
 /
 show err

--- a/src/pljson_element.type.decl.sql
+++ b/src/pljson_element.type.decl.sql
@@ -57,7 +57,8 @@ create or replace type pljson_element force as object
   member procedure print(self in pljson_element, spaces boolean default true, chars_per_line number default 8192, jsonp varchar2 default null),
   member procedure htp(self in pljson_element, spaces boolean default false, chars_per_line number default 0, jsonp varchar2 default null),
 
-  member function internal_path_put(self in out nocopy pljson_element, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
+  /** Private method for internal processing. */
+  member function put_internal_path(self in out nocopy pljson_element, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
 ) not final
 /
 show err

--- a/src/pljson_element.type.impl.sql
+++ b/src/pljson_element.type.impl.sql
@@ -152,6 +152,11 @@ create or replace type body pljson_element as
     pljson_printer.htp_output_clob(my_clob, jsonp);
     dbms_lob.freetemporary(my_clob);
   end;
+
+  member function internal_path_put(self in out nocopy pljson_element, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
+  begin
+    return false;
+  end;
 end;
 /
 show err

--- a/src/pljson_element.type.impl.sql
+++ b/src/pljson_element.type.impl.sql
@@ -153,7 +153,8 @@ create or replace type body pljson_element as
     dbms_lob.freetemporary(my_clob);
   end;
 
-  member function internal_path_put(self in out nocopy pljson_element, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
+  /** Private method for internal processing. */
+  member function put_internal_path(self in out nocopy pljson_element, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
   begin
     return false;
   end;

--- a/src/pljson_ext.decl.sql
+++ b/src/pljson_ext.decl.sql
@@ -25,6 +25,16 @@ create or replace package pljson_ext as
      an easy way of adding date values in json - without changing the structure */
   function parsePath(json_path varchar2, base number default 1) return pljson_list;
 
+  --JSON pre-parsed path getters
+  function get_json_element(obj pljson, path pljson_list) return pljson_element;
+  function get_string(obj pljson, path pljson_list) return varchar2;
+  function get_number(obj pljson, path pljson_list) return number;
+  function get_double(obj pljson, path pljson_list) return binary_double;
+  function get_json(obj pljson, path pljson_list) return pljson;
+  function get_json_list(obj pljson, path pljson_list) return pljson_list;
+  function get_bool(obj pljson, path pljson_list) return boolean;
+  function get_date(obj pljson, path pljson_list) return date;
+
   --JSON Path getters
   function get_json_element(obj pljson, v_path varchar2, base number default 1) return pljson_element;
   function get_string(obj pljson, path varchar2,       base number default 1) return varchar2;

--- a/src/pljson_ext.decl.sql
+++ b/src/pljson_ext.decl.sql
@@ -34,6 +34,16 @@ create or replace package pljson_ext as
   function get_json_list(obj pljson, path varchar2,    base number default 1) return pljson_list;
   function get_bool(obj pljson, path varchar2,         base number default 1) return boolean;
 
+  --JSON pre-parsed path putters
+  procedure put(obj in out nocopy pljson, path pljson_list, elem varchar2);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem number);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem binary_double);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem pljson);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem pljson_list);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem boolean);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem pljson_element);
+  procedure put(obj in out nocopy pljson, path pljson_list, elem date);
+
   --JSON Path putters
   procedure put(obj in out nocopy pljson, path varchar2, elem varchar2,   base number default 1);
   procedure put(obj in out nocopy pljson, path varchar2, elem number,     base number default 1);

--- a/src/pljson_ext.decl.sql
+++ b/src/pljson_ext.decl.sql
@@ -63,6 +63,7 @@ create or replace package pljson_ext as
   procedure put(obj in out nocopy pljson, path varchar2, elem boolean,    base number default 1);
   procedure put(obj in out nocopy pljson, path varchar2, elem pljson_element, base number default 1);
 
+  procedure remove(obj in out nocopy pljson, path pljson_list);
   procedure remove(obj in out nocopy pljson, path varchar2, base number default 1);
 
   --Pretty print with JSON Path - obsolete in 0.9.4 - obj.path(v_path).(to_char,print,htp)

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -514,7 +514,7 @@ create or replace package body pljson_ext as
       end if;
     end loop;
 
-    dummy := obj.internal_path_put(path_segments, elem, 1);
+    dummy := obj.put_internal_path(path_segments, elem, 1);
   end;
 
   /* JSON Path putter internal function */

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -287,14 +287,12 @@ create or replace package body pljson_ext as
 
     return ret;
   end parsePath;
-  
-  --JSON Path getters
-  function get_json_element(obj pljson, v_path varchar2, base number default 1) return pljson_element as
-    path pljson_list;
+
+  --JSON pre-parsed path getters
+  function get_json_element(obj pljson, path pljson_list) return pljson_element as
     ret pljson_element;
     o pljson; l pljson_list;
   begin
-    path := parsePath(v_path, base);
     ret := obj;
     if (path.count = 0) then return ret; end if;
 
@@ -336,7 +334,91 @@ create or replace package body pljson_ext as
     when others then return null;
   end get_json_element;
 
+  function get_string(obj pljson, path pljson_list) return varchar2 as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not temp.is_string()) then
+      return null;
+    else
+      return temp.get_string();
+    end if;
+  end;
+
+  function get_number(obj pljson, path pljson_list) return number as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not temp.is_number()) then
+      return null;
+    else
+      return temp.get_number();
+    end if;
+  end;
+
+  function get_double(obj pljson, path pljson_list) return binary_double as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not temp.is_number()) then
+      return null;
+    else
+      return temp.get_double();
+    end if;
+  end;
+
+  function get_json(obj pljson, path pljson_list) return pljson as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not temp.is_object()) then
+      return null;
+    else
+      return treat(temp as pljson);
+    end if;
+  end;
+
+  function get_json_list(obj pljson, path pljson_list) return pljson_list as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not temp.is_array()) then
+      return null;
+    else
+      return treat(temp as pljson_list);
+    end if;
+  end;
+
+  function get_bool(obj pljson, path pljson_list) return boolean as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not temp.is_bool()) then
+      return null;
+    else
+      return temp.get_bool();
+    end if;
+  end;
+
+  function get_date(obj pljson, path pljson_list) return date as
+    temp pljson_element;
+  begin
+    temp := get_json_element(obj, path);
+    if (temp is null or not is_date(temp)) then
+      return null;
+    else
+      return pljson_ext.to_date(temp);
+    end if;
+  end;
+
   --JSON Path getters
+  function get_json_element(obj pljson, v_path varchar2, base number default 1) return pljson_element as
+    path pljson_list;
+  begin
+    path := parsePath(v_path, base);
+    return get_json_element(obj, path);
+  end get_json_element;
+
   function get_string(obj pljson, path varchar2, base number default 1) return varchar2 as
     temp pljson_element;
   begin

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -415,10 +415,9 @@ create or replace package body pljson_ext as
     end if;
   end;
 
-  /* JSON Path putter internal function */
-  procedure put_internal(obj in out nocopy pljson, v_path varchar2, elem pljson_element, base number) as
+  /* JSON pre-parsed path putter internal function */
+  procedure put_internal_preparsed(obj in out nocopy pljson, path pljson_list, elem pljson_element) as
     val pljson_element := elem;
-    path pljson_list;
     backreference pljson_list := pljson_list();
 
     keyval pljson_element; keynum number; keystring varchar2(4000);
@@ -427,7 +426,6 @@ create or replace package body pljson_ext as
     list_temp pljson_list;
     inserter pljson_element;
   begin
-    path := pljson_ext.parsePath(v_path, base);
     if (path.count = 0) then raise_application_error(-20110, 'PLJSON_EXT put error: cannot put with empty string.'); end if;
 
     --build backreference
@@ -550,8 +548,88 @@ create or replace package body pljson_ext as
       end if;
 
     end loop;
+  end;
 
+  /* JSON Path putter internal function */
+  procedure put_internal(obj in out nocopy pljson, v_path varchar2, elem pljson_element, base number) as
+    path pljson_list;
+  begin
+    path := pljson_ext.parsePath(v_path, base);
+    put_internal_preparsed(obj, path, elem);
   end put_internal;
+
+  /* JSON pre-parsed path putters */
+  procedure put(obj in out nocopy pljson, path pljson_list, elem varchar2) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, pljson_string(elem));
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem number) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, pljson_number(elem));
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem binary_double) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, pljson_number(elem));
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem pljson) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, elem);
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem pljson_list) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, elem);
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem boolean) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, pljson_bool(elem));
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem pljson_element) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, elem);
+    end if;
+  end;
+
+  procedure put(obj in out nocopy pljson, path pljson_list, elem date) as
+  begin
+    if elem is null then
+      put_internal_preparsed(obj, path, pljson_null());
+    else
+      put_internal_preparsed(obj, path, pljson_ext.to_json_string(elem));
+    end if;
+  end;
 
   /* JSON Path putters */
   procedure put(obj in out nocopy pljson, path varchar2, elem varchar2, base number default 1) as

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -787,6 +787,11 @@ create or replace package body pljson_ext as
     end if;
   end;
 
+  procedure remove(obj in out nocopy pljson, path pljson_list) as
+  begin
+    pljson_ext.put_internal_preparsed(obj, path, null);
+  end remove;
+
   procedure remove(obj in out nocopy pljson, path varchar2, base number default 1) as
   begin
     pljson_ext.put_internal(obj, path, null, base);

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -40,6 +40,7 @@ create or replace type pljson_list force under pljson_element (
   constructor function pljson_list(str_array pljson_varray) return self as result,
   constructor function pljson_list(num_array pljson_narray) return self as result,
   constructor function pljson_list(elem pljson_element) return self as result,
+  constructor function pljson_list(elem_array pljson_element_array) return self as result,
   overriding member function is_array return boolean,
   overriding member function value_of(max_byte_size number default null, max_char_size number default null) return varchar2,
 

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -92,7 +92,9 @@ create or replace type pljson_list force under pljson_element (
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem pljson_list, base number default 1),
 
   /* json path_remove */
-  member procedure path_remove(self in out nocopy pljson_list, json_path varchar2, base number default 1)
+  member procedure path_remove(self in out nocopy pljson_list, json_path varchar2, base number default 1),
+
+  overriding member function internal_path_put(self in out nocopy pljson_list, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
 ) not final;
 /
 show err

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -94,7 +94,8 @@ create or replace type pljson_list force under pljson_element (
   /* json path_remove */
   member procedure path_remove(self in out nocopy pljson_list, json_path varchar2, base number default 1),
 
-  overriding member function internal_path_put(self in out nocopy pljson_list, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
+  /** Private method for internal processing. */
+  overriding member function put_internal_path(self in out nocopy pljson_list, path pljson_path, elem pljson_element, path_position pls_integer) return boolean
 ) not final;
 /
 show err

--- a/src/pljson_list.type.impl.sql
+++ b/src/pljson_list.type.impl.sql
@@ -85,30 +85,30 @@ create or replace type body pljson_list as
   /* list management */
   member procedure append(self in out nocopy pljson_list, elem pljson_element, position pls_integer default null) as
     indx pls_integer;
-    insert_value pljson_element;
   begin
-    insert_value := elem;
-    if insert_value is null then
-      insert_value := pljson_null();
-    end if;
     if (position is null or position > self.count) then --end of list
       indx := self.count + 1;
       self.list_data.extend(1);
-      self.list_data(indx) := insert_value;
     elsif (position < 1) then --new first
       indx := self.count;
       self.list_data.extend(1);
       for x in reverse 1 .. indx loop
         self.list_data(x+1) := self.list_data(x);
       end loop;
-      self.list_data(1) := insert_value;
+      indx := 1;
     else
       indx := self.count;
       self.list_data.extend(1);
       for x in reverse position .. indx loop
         self.list_data(x+1) := self.list_data(x);
       end loop;
-      self.list_data(position) := insert_value;
+      indx := position;
+    end if;
+
+    if elem is not null then
+      self.list_data(indx) := elem;
+    else
+      self.list_data(indx) := pljson_null();
     end if;
   end;
 

--- a/src/pljson_list.type.impl.sql
+++ b/src/pljson_list.type.impl.sql
@@ -488,7 +488,8 @@ create or replace type body pljson_list as
     self := objlist.get_values;
   end path_remove;
 
-  overriding member function internal_path_put(self in out nocopy pljson_list, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
+  /** Private method for internal processing. */
+  overriding member function put_internal_path(self in out nocopy pljson_list, path pljson_path, elem pljson_element, path_position pls_integer) return boolean as
     indx pls_integer := path(path_position).indx;
   begin
     indx := path(path_position).indx;
@@ -524,7 +525,7 @@ create or replace type body pljson_list as
         end if;
       end if;
 
-      if (self.list_data(indx).internal_path_put(path, elem, path_position + 1)) then
+      if (self.list_data(indx).put_internal_path(path, elem, path_position + 1)) then
         self.remove(indx);
         return self.list_data.count = 0;
       end if;

--- a/src/pljson_list.type.impl.sql
+++ b/src/pljson_list.type.impl.sql
@@ -65,6 +65,13 @@ create or replace type body pljson_list as
     return;
   end;
 
+  constructor function pljson_list(elem_array pljson_element_array) return self as result as
+  begin
+    self.list_data := elem_array;
+    self.typeval := 2;
+    return;
+  end;
+
   overriding member function is_array return boolean as
   begin
     return true;

--- a/testsuite/pljson_path.test.sql
+++ b/testsuite/pljson_path.test.sql
@@ -276,7 +276,33 @@ begin
     pljson_ext.put(obj, '[ "a"  ][2][1 ] [ "a" ]["i"][1]["A"]', 2.718281828459e210d);
     pljson_ut.assertTrue(nvl(pljson_ext.get_double(obj, '[ "a"  ][2][1 ] [ "a" ]["i"][1]["A"]'),0) = 2.718281828459e210d, 'nvl(pljson_ext.get_double(obj, ''[ "a"  ][2][1 ] [ "a" ]["i"][1]["A"]''),0) = 2.718281828459e210d');
   end;
-  
+   
+  -- put with pre-parsed path
+  pljson_ut.testcase('Test put with pre-parsed path');
+  declare
+    obj pljson := pljson();
+  begin
+    pljson_ext.put(obj, pljson_ext.parsePath('a.b[1].c'), true);
+    pljson_ut.assertTrue(pljson_ext.get_json_list(obj, pljson_ext.parsePath('a.b')) is not null, 'pljson_ext.get_json_list(obj, pljson_ext.parsePath(''a.b'')) is not null');
+    pljson_ext.put(obj, pljson_ext.parsePath('a.b[1].c'), false);
+    --dbms_output.put_line('Put false');
+    --obj.print;
+    pljson_ut.assertTrue(pljson_ext.get_json_list(obj, pljson_ext.parsePath('a.b')) is not null, 'pljson_ext.get_json_list(obj, pljson_ext.parsePath(''a.b'')) is not null');
+    pljson_ut.assertFalse(pljson_ext.get_json_element(obj, pljson_ext.parsePath('a.b[1].c')).get_bool, 'pljson_ext.get_json_element(obj, pljson_ext.parsePath(''a.b[1].c'')).get_bool');
+  end;
+ 
+  -- remove with pre-parsed path
+  pljson_ut.testcase('Test remove with pre-parsed path');
+  declare
+    obj pljson := pljson('{"a":true, "b":[[]]}');
+  begin
+    pljson_ext.remove(obj, pljson_ext.parsePath('a'));
+    pljson_ut.assertFalse(obj.exist('a'), 'obj.exist(''a'')');
+    pljson_ut.assertTrue(obj.count = 1, 'obj.count = 1');
+    pljson_ext.remove(obj, pljson_ext.parsePath('b[1]'));
+    pljson_ut.assertFalse(obj.exist('b'), 'obj.exist(''b'')');
+  end;
+
   pljson_ut.testsuite_report;
   
 end;

--- a/uninstall.sql
+++ b/uninstall.sql
@@ -41,6 +41,8 @@ begin
   begin execute immediate 'drop type pljson_null force'; exception when others then null; end;
   begin execute immediate 'drop type pljson_element_array force'; exception when others then null; end;
   begin execute immediate 'drop type pljson_element force'; exception when others then null; end;
+  begin execute immediate 'drop type pljson_path_segment force'; exception when others then null; end;
+  begin execute immediate 'drop type pljson_path force'; exception when others then null; end;
   begin execute immediate 'drop type pljson_narray force'; exception when others then null; end;
   begin execute immediate 'drop type pljson_vtab force'; exception when others then null; end;
   begin execute immediate 'drop type pljson_varray force'; exception when others then null; end;


### PR DESCRIPTION
This pull request consists of:
- New pre-parsed based path `put`/`remove` methods
- Optimization of already existing string-based path `put`/`remove` methods
- New constructor for `pljson_list` with `pljson_element_array` parameter

With pre-parsed path I see an 84% improvement comparing with the equivalent string-based path:

```
-- 9.4s x 1.5s - 84% improvement
declare
  obj pljson := pljson('{}');
  path pljson_list := pljson_list(pljson_element_array(pljson_string('p1'), pljson_string('p2'), pljson_string('p3'), pljson_string('p4')));
  n1 pljson_element := pljson_number(1);
begin
  for i in 1 .. 10000
  loop
    pljson_ext.put(obj, path, n1);
  end loop;
end;
/
```

Here are tests comparing the old and the new timings with string-based path having close of 50% improvement:

```
-- 9.4s x 5.5s - 41% improvement
declare
  obj pljson := pljson('{}');
  n1 pljson_element := pljson_number(1);
begin
  for i in 1 .. 10000
  loop
    pljson_ext.put(obj, 'p1.p2.p3.p4', n1);
  end loop;
end;
/
```

```
-- 11.5s x 6.0s - 48% improvement
declare
  obj pljson := pljson('{}');
  n1 pljson_element := pljson_number(1);
begin
  for i in 1 .. 10000
  loop
    pljson_ext.put(obj, 'x[1][2][3]', n1);
  end loop;
end;
/
```

```
-- 3.6s x 3.1s - 14% improvement
declare
  obj pljson := pljson('{}');
  n1 pljson_element := pljson_number(1);
begin
  for i in 1 .. 10000
  loop
    pljson_ext.put(obj, 'p1', n1);
  end loop;
end;
/
```

Relates to #124 