### PR TITLE
Make path-based get much faster.

### DIFF
--- a/src/pljson.type.decl.sql
+++ b/src/pljson.type.decl.sql
@@ -77,6 +77,9 @@ create or replace type pljson force under pljson_element (
   /* json path */
   overriding member function path(json_path varchar2, base number default 1) return pljson_element,
 
+  /** Private method for internal processing. */
+  overriding member procedure get_internal_path(self in pljson, path pljson_path, path_position pls_integer, ret out nocopy pljson_element),
+
   /* json path_put */
   member procedure path_put(self in out nocopy pljson, json_path varchar2, elem pljson_element, base number default 1),
   member procedure path_put(self in out nocopy pljson, json_path varchar2, elem varchar2, base number default 1),

--- a/src/pljson_element.type.decl.sql
+++ b/src/pljson_element.type.decl.sql
@@ -51,6 +51,9 @@ create or replace type pljson_element force as object
 
   member function path(json_path varchar2, base number default 1) return pljson_element,
 
+  /** Private method for internal processing. */
+  member procedure get_internal_path(self in pljson_element, path pljson_path, path_position pls_integer, ret out nocopy pljson_element),
+
   /* output methods */
   member function to_char(spaces boolean default true, chars_per_line number default 0) return varchar2,
   member procedure to_clob(self in pljson_element, buf in out nocopy clob, spaces boolean default false, chars_per_line number default 0, erase_clob boolean default true),

--- a/src/pljson_element.type.impl.sql
+++ b/src/pljson_element.type.impl.sql
@@ -114,6 +114,12 @@ create or replace type body pljson_element as
     raise_application_error(-20010, 'path() method is not supported by object of type:'  || get_type());
   end;
 
+  /** Private method for internal processing. */
+  member procedure get_internal_path(self in pljson_element, path pljson_path, path_position pls_integer, ret out nocopy pljson_element) as
+  begin
+    raise_application_error(-20010, 'path() method is not supported by object of type:'  || get_type());
+  end;
+
   /* output methods */
   member function to_char(spaces boolean default true, chars_per_line number default 0) return varchar2 as
   begin

--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -290,42 +290,24 @@ create or replace package body pljson_ext as
 
   --JSON pre-parsed path getters
   function get_json_element(obj pljson, path pljson_list) return pljson_element as
+    path_segments pljson_path := pljson_path();
     ret pljson_element;
-    o pljson; l pljson_list;
   begin
-    ret := obj;
-    if (path.count = 0) then return ret; end if;
+    if (path.count = 0) then
+      return null;
+    end if;
 
     for i in 1 .. path.count loop
-      if (path.get(i).is_string()) then
-        --string fetch only on json
-        ------o := pljson(ret);
-        ------ret := o.get(path.get(i).get_string());
-        /* E.I.Sarmas (github.com/dsnz)   2020-04-18   use inheritance and avoid treat() */
-        ret := ret.get(path.get(i).get_string());
-        --experimental, ignore
-        --ret := get_piece(o, path.get(i).get_string());
+      path_segments.extend;
+
+      if (path.get(i).is_number()) then
+        path_segments(path_segments.count) := pljson_path_segment(path.get(i).get_number(), null);
       else
-        --number fetch on json and json_list
-        if (ret.is_array()) then
-          ------l := pljson_list(ret);
-          ------ret := l.get(path.get(i).get_number());
-          /* E.I.Sarmas (github.com/dsnz)   2020-04-18   use inheritance and avoid treat() */
-          ret := ret.get(path.get(i).get_number());
-          --experimental, ignore
-          --ret := get_piece(l, path.get(i).get_number());
-        else
-          ------o := pljson(ret);
-          ------l := o.get_values();
-          ------ret := l.get(path.get(i).get_number());
-          /* E.I.Sarmas (github.com/dsnz)   2020-04-18   use inheritance and avoid treat() */
-          ret := ret.get(path.get(i).get_number());
-          --experimental, ignore
-          --ret := get_piece(l, path.get(i).get_number());
-        end if;
+        path_segments(path_segments.count) := pljson_path_segment(null, path.get(i).get_string());
       end if;
     end loop;
 
+    obj.get_internal_path(path_segments, 1, ret);
     return ret;
   exception
     when scanner_exception then raise;

--- a/src/pljson_list.type.decl.sql
+++ b/src/pljson_list.type.decl.sql
@@ -81,6 +81,10 @@ create or replace type pljson_list force under pljson_element (
 
   /* json path */
   overriding member function path(json_path varchar2, base number default 1) return pljson_element,
+
+  /** Private method for internal processing. */
+  overriding member procedure get_internal_path(self in pljson_list, path pljson_path, path_position pls_integer, ret out nocopy pljson_element),
+
   /* json path_put */
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem pljson_element, base number default 1),
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem varchar2, base number default 1),

--- a/src/pljson_list.type.impl.sql
+++ b/src/pljson_list.type.impl.sql
@@ -371,6 +371,21 @@ create or replace type body pljson_list as
     return pljson_ext.get_json_element(pljson(cp), json_path, base);
   end path;
 
+  /** Private method for internal processing. */
+  overriding member procedure get_internal_path(self in pljson_list, path pljson_path, path_position pls_integer, ret out nocopy pljson_element) as
+    indx pls_integer := path(path_position).indx;
+  begin
+    indx := path(path_position).indx;
+
+    if (indx <= self.list_data.count) then
+      if (path_position < path.count) then
+        self.list_data(indx).get_internal_path(path, path_position + 1, ret);
+      else
+        ret := self.list_data(indx);
+      end if;
+    end if;
+  end;
+
   /* json path_put */
   member procedure path_put(self in out nocopy pljson_list, json_path varchar2, elem pljson_element, base number default 1) as
     objlist pljson;


### PR DESCRIPTION
This uses similar technique than https://github.com/pljson/pljson/pull/205 but now for `get`.

Timings comparison:

String-based paths:
```
-- 40.2 x 13.2 - 67% improvement
declare
  list pljson_list := pljson_list();
  path varchar2(255) := 'level1.level2.list[4]';
  obj pljson;
  obj2 pljson;
  elem pljson_element;
begin
  for i in 1 .. 100
  loop
    for j in 1 .. 10
    loop
        obj2 := pljson();
        obj2.put('a', 1);
        obj2.put('b', 1);
        list.append(obj2);
    end loop;
  end loop;

  obj := pljson();
  pljson_ext.put(obj, 'level1.level2.list', list);

  for i in 1 .. 1000
  loop
    elem := pljson_ext.get_json_element(obj, path);
  end loop;
end;
/
```

Pre-parsed path with original algorithm (as currently in develop_v3 branch):

```
-- 36.8 x 12.4 - 66% improvement
declare
  list pljson_list := pljson_list();
  path pljson_list := pljson_list(pljson_element_array(pljson_string('level1'), pljson_string('level2'), pljson_string('list'), pljson_number(4)));
  obj pljson;
  obj2 pljson;
  elem pljson_element;
begin
  for i in 1 .. 100
  loop
    for j in 1 .. 10
    loop
        obj2 := pljson();
        obj2.put('a', 1);
        obj2.put('b', 1);
        list.append(obj2);
    end loop;
  end loop;

  obj := pljson();
  pljson_ext.put(obj, 'level1.level2.list', list);

  for i in 1 .. 1000
  loop
    elem := pljson_ext.get_json_element(obj, path);
  end loop;
end;
/
```