### PR TITLE
Add colon as acceptable character

### DIFF
--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -204,13 +204,13 @@ create or replace package body pljson_ext as
       if (buf = '.') then
         next_char();
         if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: . is not a valid json_path end'); end if;
-        if (not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if (not regexp_like(buf, '^[[:alnum:]\_ :]+', 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
 
         if (build_path != '[') then build_path := build_path || ','; end if;
         build_path := build_path || '"';
-        while (regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while (regexp_like(buf, '^[[:alnum:]\_ :]+', 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;
@@ -252,11 +252,11 @@ create or replace package body pljson_ext as
         next_char();
         skipws();
       elsif (build_path = '[') then
-        if (not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if (not regexp_like(buf, '^[[:alnum:]\_ :]+', 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
         build_path := build_path || '"';
-        while (regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while (regexp_like(buf, '^[[:alnum:]\_ :]+', 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;


### PR DESCRIPTION
A JSON key can also contain a colon. I've updated pljson_ext.parsePath to reflect that.