### PR TITLE
parsePath function correction/upgrade

### DIFF
--- a/src/pljson_ext.impl.sql
+++ b/src/pljson_ext.impl.sql
@@ -185,6 +185,7 @@ create or replace package body pljson_ext as
     endstring varchar2(1);
     indx number := 1;
     ret pljson_list;
+    c_regexp constant varchar2(32) := '^[[:alnum:]\_ |-]+';
 
     procedure next_char as
     begin
@@ -204,13 +205,13 @@ create or replace package body pljson_ext as
       if (buf = '.') then
         next_char();
         if (buf is null) then raise_application_error(-20110, 'JSON Path parse error: . is not a valid json_path end'); end if;
-        if (not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if (not regexp_like(buf, c_regexp, 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
 
         if (build_path != '[') then build_path := build_path || ','; end if;
         build_path := build_path || '"';
-        while (regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while (regexp_like(buf, c_regexp, 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;
@@ -252,11 +253,11 @@ create or replace package body pljson_ext as
         next_char();
         skipws();
       elsif (build_path = '[') then
-        if (not regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) then
+        if (not regexp_like(buf, c_regexp, 'c') ) then
           raise_application_error(-20110, 'JSON Path parse error: alpha-numeric character or space expected at position '||indx);
         end if;
         build_path := build_path || '"';
-        while (regexp_like(buf, '^[[:alnum:]\_ ]+', 'c') ) loop
+        while (regexp_like(buf, c_regexp, 'c') ) loop
           build_path := build_path || buf;
           next_char();
         end loop;

--- a/testsuite/pljson.test.sql
+++ b/testsuite/pljson.test.sql
@@ -3,7 +3,7 @@
  * Test of PLSQL JSON Object by Jonas Krogsboell
  **/
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 begin
   

--- a/testsuite/pljson_base64.test.sql
+++ b/testsuite/pljson_base64.test.sql
@@ -6,7 +6,7 @@
  *
  **/
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 set linesize 66
 
 declare

--- a/testsuite/pljson_ext.test.sql
+++ b/testsuite/pljson_ext.test.sql
@@ -3,7 +3,7 @@
  * Test of PLSQL JSON_Ext by Jonas Krogsboell
  **/
  
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 declare
   

--- a/testsuite/pljson_helper.test.sql
+++ b/testsuite/pljson_helper.test.sql
@@ -3,7 +3,7 @@
  * Test of pljson_helper addon package
  **/
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 declare
   

--- a/testsuite/pljson_list.test.sql
+++ b/testsuite/pljson_list.test.sql
@@ -3,7 +3,7 @@
  * Test of PLSQL JSON List by Jonas Krogsboell
  **/
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 declare
   

--- a/testsuite/pljson_parser.test.sql
+++ b/testsuite/pljson_parser.test.sql
@@ -3,7 +3,7 @@
  * Test of PLSQL JSON Parser by Jonas Krogsboell
  **/
 
- set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 declare
   

--- a/testsuite/pljson_path.test.sql
+++ b/testsuite/pljson_path.test.sql
@@ -3,7 +3,7 @@
  * Test of JSON Path imple. in JSON_Ext by Jonas Krogsboell
  **/
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 begin
   

--- a/testsuite/pljson_simple.test.sql
+++ b/testsuite/pljson_simple.test.sql
@@ -3,7 +3,7 @@
  * Test of PLSQL JSON Object by Jonas Krogsboell
  **/
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 begin
   

--- a/testsuite/pljson_unicode.test.sql
+++ b/testsuite/pljson_unicode.test.sql
@@ -9,7 +9,7 @@
 
 PROMPT did you run with NLS_LANG='AMERICAN_AMERICA.AL32UTF8' ?
 
-set serveroutput on format wrapped
+set serveroutput on size 20000 format wrapped
 
 declare
   test_json pljson;


### PR DESCRIPTION
1. parse path function correction:
current implemetation didn't allow "minus" sign in path parameter

example:
function call
pljson_ext.get_json_list(obj_json, 'transaction**-**items')
was not possible and it throwed an exception

2. increased serveroutput buffer in test scripts

                    SUITE_NAME  PASSED  FAILED   TOTAL                      FILE_NAME
------------------------------ ------- ------- ------- ------------------------------
            pljson_parser test      14       0      14         pljson_parser.test.sql
                   pljson test      16       0      16                pljson.test.sql
              pljson_list test      20       0      20           pljson_list.test.sql
            pljson simple test       4       0       4         pljson_simple.test.sql
               pljson_ext test       5       0       5            pljson_ext.test.sql
              pljson_path test      15       0      15           pljson_path.test.sql
        pljson_ext base64 test       4       0       4         pljson_base64.test.sql
------------------------------ ------- ------- ------- ------------------------------
                     ALL TESTS      81       3      81