### PR TITLE
Fix null check for string values in pljson_xml

### DIFF
--- a/src/addons/pljson_xml.package.sql
+++ b/src/addons/pljson_xml.package.sql
@@ -126,7 +126,7 @@ create or replace package body pljson_xml as
               end if;
             end loop;
           end;
-        elsif (v_value.is_null() or (v_value.is_string() and v_value.get_string() = '')) then
+        elsif (v_value.is_null() or (v_value.is_string() and v_value.get_string() is null)) then
           add_to_clob(xmlstr, xmlbuf, '<' || key_str || '/>');
         else
           toString(v_value, key_str, xmlstr, xmlbuf);


### PR DESCRIPTION
Hi,

This update fixes an incorrect null comparison in the pljson_xml package by changing the condition from `= ''` to the correct `is null` condition.

Here's a quick example showing the change in the output:

```sql
declare 
  obj pljson := pljson();
  output xmltype;
  varchar_var varchar2(1);
  clob_val clob;
  num_val number;
begin
  obj.put('varchar2', varchar_var);
  obj.put('clob', clob_val);
  obj.put('number', num_val);
  output := pljson_xml.json_to_xml(obj);
  dbms_output.put_line(output.getstringval);
end;
```

The output is `<?xml version="1.0"?><root><varchar2></varchar2><clob/><number/></root>`.

After this change, the "varchar2" element will also become a self-closing tag, similar to the other elements: `<?xml version="1.0"?><root><varchar2/><clob/><number/></root>`.